### PR TITLE
refactor: remove hardcoded credentials from weekly DAST workflow auth

### DIFF
--- a/.github/workflows/ci-weekly-dast.yml
+++ b/.github/workflows/ci-weekly-dast.yml
@@ -45,11 +45,8 @@ jobs:
       BLOCK_MEDIUM_CATEGORIES: "1"
       BLOCK_MEDIUM_PLUGINIDS: ""
 
-      ZAP_LOGIN_EMAIL: ${{ vars.ZAP_LOGIN_EMAIL }}
-      ZAP_LOGIN_PASSWORD: ${{ secrets.ZAP_LOGIN_PASSWORD }}
-      ZAP_DEMO_LOGIN_EMAIL: john.smith@stayhealthy.test
-      ZAP_DEMO_LOGIN_PASSWORD: DemoPass123!
-      ALLOW_DEMO_AUTH_FALLBACK: "0"
+      ZAP_LOGIN_EMAIL: ${{ vars.ADMIN_USER }}
+      ZAP_LOGIN_PASSWORD: ${{ secrets.ADMIN_PASS }}
       DEBUG_DAST: "0"
 
       AUTH_COVERAGE_REGEX: '/api/v2/'
@@ -140,18 +137,9 @@ jobs:
           LOGIN_EMAIL="${{ env.ZAP_LOGIN_EMAIL }}"
           LOGIN_PASSWORD="${{ env.ZAP_LOGIN_PASSWORD }}"
 
-          if [ -z "$LOGIN_EMAIL" ]; then
-            LOGIN_EMAIL="${{ env.ZAP_DEMO_LOGIN_EMAIL }}"
-          fi
-
-          if [ -z "$LOGIN_PASSWORD" ]; then
-            if [ "${{ env.ALLOW_DEMO_AUTH_FALLBACK }}" = "1" ]; then
-              LOGIN_PASSWORD="${{ env.ZAP_DEMO_LOGIN_PASSWORD }}"
-              echo "::warning::Using demo auth fallback password for DAST execution."
-            else
-              echo "::error::Missing secrets.ZAP_LOGIN_PASSWORD and ALLOW_DEMO_AUTH_FALLBACK=0. Configure the secret or explicitly enable fallback."
-              exit 1
-            fi
+          if [ -z "$LOGIN_EMAIL" ] || [ -z "$LOGIN_PASSWORD" ]; then
+            echo "::error::Missing vars.ADMIN_USER and/or secrets.ADMIN_PASS for DAST auth bootstrap."
+            exit 1
           fi
 
           echo "::add-mask::${LOGIN_EMAIL}"
@@ -272,18 +260,9 @@ jobs:
           LOGIN_EMAIL="${{ env.ZAP_LOGIN_EMAIL }}"
           LOGIN_PASSWORD="${{ env.ZAP_LOGIN_PASSWORD }}"
 
-          if [ -z "$LOGIN_EMAIL" ]; then
-            LOGIN_EMAIL="${{ env.ZAP_DEMO_LOGIN_EMAIL }}"
-          fi
-
-          if [ -z "$LOGIN_PASSWORD" ]; then
-            if [ "${{ env.ALLOW_DEMO_AUTH_FALLBACK }}" = "1" ]; then
-              LOGIN_PASSWORD="${{ env.ZAP_DEMO_LOGIN_PASSWORD }}"
-              echo "::warning::Using demo auth fallback password for DAST execution."
-            else
-              echo "::error::Missing secrets.ZAP_LOGIN_PASSWORD and ALLOW_DEMO_AUTH_FALLBACK=0. Configure the secret or explicitly enable fallback."
-              exit 1
-            fi
+          if [ -z "$LOGIN_EMAIL" ] || [ -z "$LOGIN_PASSWORD" ]; then
+            echo "::error::Missing vars.ADMIN_USER and/or secrets.ADMIN_PASS for DAST auth refresh."
+            exit 1
           fi
 
           echo "::add-mask::${LOGIN_EMAIL}"


### PR DESCRIPTION
### Motivation

- Remove embedded demo credentials and fallback logic from the weekly DAST workflow to avoid hardcoded secret-like values.
- Align DAST authentication with the app's existing secret pattern (use the same admin credential variables the app uses).

### Description

- Replaced workflow envs `ZAP_LOGIN_EMAIL`/`ZAP_LOGIN_PASSWORD` and removed demo fallback vars with `ZAP_LOGIN_EMAIL: ${{ vars.ADMIN_USER }}` and `ZAP_LOGIN_PASSWORD: ${{ secrets.ADMIN_PASS }}` in `.github/workflows/ci-weekly-dast.yml`.
- Removed hardcoded demo email/password and `ALLOW_DEMO_AUTH_FALLBACK` handling entirely.
- Added fail-fast guard checks in both the auth bootstrap and auth refresh steps so the job exits with a clear error if `vars.ADMIN_USER` or `secrets.ADMIN_PASS` are missing.
- Kept all other DAST behavior intact (ZAP runs, OpenAPI rewrite, SARIF generation, artifacts, teardown).

### Testing

- Confirmed removal of demo values and fallbacks by running `rg -n "ZAP_DEMO|ALLOW_DEMO|DemoPass|stayhealthy\.test|ZAP_LOGIN_PASSWORD|ZAP_LOGIN_EMAIL" .github/workflows/ci-weekly-dast.yml` which showed only the new `vars.ADMIN_USER` / `secrets.ADMIN_PASS` references.
- Reviewed changes with `git diff`/file inspection (`nl` + `sed`) to verify the updated env wiring and the new guard checks; the checks succeeded and the expected lines were present.
- Performed repository status checks to ensure the updated workflow file is staged in the working tree; those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698febceb6e4832d8a810f01e3a563c5)