### PR TITLE
fix(ci): make weekly DAST v2 auth credentials explicit and deterministic

### DIFF
--- a/.github/workflows/ci-weekly-dast.yml
+++ b/.github/workflows/ci-weekly-dast.yml
@@ -47,9 +47,6 @@ jobs:
 
       ZAP_LOGIN_EMAIL: ${{ vars.ZAP_LOGIN_EMAIL }}
       ZAP_LOGIN_PASSWORD: ${{ secrets.ZAP_LOGIN_PASSWORD }}
-      ZAP_DEMO_LOGIN_EMAIL: john.smith@stayhealthy.test
-      ZAP_DEMO_LOGIN_PASSWORD: DemoPass123!
-      ALLOW_DEMO_AUTH_FALLBACK: "0"
       DEBUG_DAST: "0"
 
       AUTH_COVERAGE_REGEX: '/api/v2/'
@@ -80,6 +77,8 @@ jobs:
             echo "DATA_ENCRYPTION_KEY=${{ secrets.DATA_ENCRYPTION_KEY }}"
             echo "COMPOSE_PROJECT_NAME=${{ env.COMPOSE_PROJECT_NAME }}"
             echo "SECRETS_PATH=${SECRETS_PATH}"
+            echo "SEED_ADMIN_EMAIL=${{ vars.ZAP_LOGIN_EMAIL }}"
+            echo "SEED_DEFAULT_PASSWORD=${{ secrets.ZAP_LOGIN_PASSWORD }}"
           } >> "$ENV_FILE"
           chmod 600 "$ENV_FILE"
 
@@ -140,18 +139,9 @@ jobs:
           LOGIN_EMAIL="${{ env.ZAP_LOGIN_EMAIL }}"
           LOGIN_PASSWORD="${{ env.ZAP_LOGIN_PASSWORD }}"
 
-          if [ -z "$LOGIN_EMAIL" ]; then
-            LOGIN_EMAIL="${{ env.ZAP_DEMO_LOGIN_EMAIL }}"
-          fi
-
-          if [ -z "$LOGIN_PASSWORD" ]; then
-            if [ "${{ env.ALLOW_DEMO_AUTH_FALLBACK }}" = "1" ]; then
-              LOGIN_PASSWORD="${{ env.ZAP_DEMO_LOGIN_PASSWORD }}"
-              echo "::warning::Using demo auth fallback password for DAST execution."
-            else
-              echo "::error::Missing secrets.ZAP_LOGIN_PASSWORD and ALLOW_DEMO_AUTH_FALLBACK=0. Configure the secret or explicitly enable fallback."
-              exit 1
-            fi
+          if [ -z "$LOGIN_EMAIL" ] || [ -z "$LOGIN_PASSWORD" ]; then
+            echo "::error::Missing vars.ZAP_LOGIN_EMAIL and/or secrets.ZAP_LOGIN_PASSWORD for DAST auth bootstrap."
+            exit 1
           fi
 
           echo "::add-mask::${LOGIN_EMAIL}"
@@ -272,18 +262,9 @@ jobs:
           LOGIN_EMAIL="${{ env.ZAP_LOGIN_EMAIL }}"
           LOGIN_PASSWORD="${{ env.ZAP_LOGIN_PASSWORD }}"
 
-          if [ -z "$LOGIN_EMAIL" ]; then
-            LOGIN_EMAIL="${{ env.ZAP_DEMO_LOGIN_EMAIL }}"
-          fi
-
-          if [ -z "$LOGIN_PASSWORD" ]; then
-            if [ "${{ env.ALLOW_DEMO_AUTH_FALLBACK }}" = "1" ]; then
-              LOGIN_PASSWORD="${{ env.ZAP_DEMO_LOGIN_PASSWORD }}"
-              echo "::warning::Using demo auth fallback password for DAST execution."
-            else
-              echo "::error::Missing secrets.ZAP_LOGIN_PASSWORD and ALLOW_DEMO_AUTH_FALLBACK=0. Configure the secret or explicitly enable fallback."
-              exit 1
-            fi
+          if [ -z "$LOGIN_EMAIL" ] || [ -z "$LOGIN_PASSWORD" ]; then
+            echo "::error::Missing vars.ZAP_LOGIN_EMAIL and/or secrets.ZAP_LOGIN_PASSWORD for DAST auth refresh."
+            exit 1
           fi
 
           echo "::add-mask::${LOGIN_EMAIL}"


### PR DESCRIPTION
### Motivation
- Remove ambiguity between v1-style admin variables and the v2 email/password login used by the DAST workflow so the scanner can reliably authenticate against `/api/v2/auth/login`.
- Ensure the seeded admin account in the ephemeral environment matches the credentials the workflow uses to log in so DAST auth is deterministic.

### Description
- Read DAST login values from `vars.ZAP_LOGIN_EMAIL` and `secrets.ZAP_LOGIN_PASSWORD` via `ZAP_LOGIN_EMAIL`/`ZAP_LOGIN_PASSWORD` workflow envs in ` .github/workflows/ci-weekly-dast.yml`.
- Write `SEED_ADMIN_EMAIL=${{ vars.ZAP_LOGIN_EMAIL }}` and `SEED_DEFAULT_PASSWORD=${{ secrets.ZAP_LOGIN_PASSWORD }}` into the generated `.env` so the seeded v2 admin account matches DAST credentials.
- Remove demo/fallback auth behavior and add fail-fast guard checks in both the auth bootstrap and auth refresh steps that emit clear errors referencing `ZAP_LOGIN_EMAIL`/`ZAP_LOGIN_PASSWORD` when missing.
- Keep all existing DAST behavior (ZAP runs, OpenAPI rewrite, SARIF generation, artifacts, teardown) unchanged.

### Testing
- Ran `git diff -- .github/workflows/ci-weekly-dast.yml` to confirm only the intended workflow file changed and it succeeded.
- Ran `rg -n "ZAP_LOGIN_EMAIL|ZAP_LOGIN_PASSWORD|SEED_ADMIN_EMAIL|SEED_DEFAULT_PASSWORD|Missing vars\." .github/workflows/ci-weekly-dast.yml` to verify the new references are present and it succeeded.
- Inspected the updated workflow segments with `nl -ba .github/workflows/ci-weekly-dast.yml | sed -n '44,54p;70,86p;134,146p;258,269p'` to confirm the seed wiring and guard messages and it succeeded.
- Ran `git status --short` and created the commit to persist the change successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698febceb6e4832d8a810f01e3a563c5)