### PR TITLE
ci: add scheduled Trivy README report automation

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -47,5 +47,15 @@ This folder contains the active GitHub Actions workflows that power CI, security
 - Triggers: schedule Mondays at 08:00 UTC, manual
 - Summary: Runs `snyk monitor` for dependencies and Dockerfiles, plus IaC and code scans (both continue-on-error) to report results to Snyk.
 
+**trivy-report.yml**
+- Name: Trivy README Update
+- Triggers: `workflow_dispatch`, weekly schedule (Sundays at 00:00 UTC), and `pull_request` closed events (cleanup path for automation branches only)
+- Summary: Runs `hack/trivy-report.sh` to produce Trivy filesystem/config scan summaries for `app/`, updates the generated marker-delimited block in `README.md`/`readme.md`, and opens a PR when the generated evidence changes. A dedicated cleanup job deletes closed automation branches prefixed with `trivy-update-` to keep branch hygiene healthy.
+- Outputs: Updated README governance evidence table in PR diff; no standalone artifact upload in this workflow.
+- Permissions/Secrets: Uses `GITHUB_TOKEN` with `contents: write` and `pull-requests: write`; no additional secrets required.
+- Maintenance notes: Keep marker strings in `hack/trivy-report.sh` and `readme.md` aligned (`<!-- [BEGIN_GENERATED_TABLE] -->` / `<!-- [END_GENERATED_TABLE] -->`), and review Trivy version pinning when upgrading scanner behavior.
+- Alert routing: Failures are visible in the Actions run and should be triaged by the platform/security maintainers who own CI governance workflows.
+- Expected result example: A weekly run creates a branch `trivy-update-<timestamp>`, opens PR `docs: weekly Trivy security scan update`, and updates only the generated table block under `## Operational Evidence`.
+
 **Notes**
 - `legacy/` contains `ci-cd.txt` and `ci-weekly-dast.txt` as historical references, not active workflows.

--- a/.github/workflows/trivy-report.yml
+++ b/.github/workflows/trivy-report.yml
@@ -1,0 +1,59 @@
+name: Trivy README Update
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 0 * * 0'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  trivy-report:
+    if: github.repository == 'agslima/software-delivery-pipeline'
+    name: Update Trivy report in README
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Make script executable
+        run: chmod +x ./hack/trivy-report.sh
+
+      - name: Run Trivy and update README
+        run: ./hack/trivy-report.sh
+
+      - name: Create pull request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$(git status --porcelain -- README.md readme.md)" ]]; then
+            echo "No README changes detected. Exiting."
+            exit 0
+          fi
+
+          pr_branch="trivy-update-$(date +%Y%m%d%H%M%S)"
+          git checkout -b "$pr_branch"
+
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+
+          if [[ -f README.md ]]; then
+            git add README.md
+          fi
+
+          if [[ -f readme.md ]]; then
+            git add readme.md
+          fi
+
+          git commit -m "docs: update Trivy security report in README"
+          git push --set-upstream origin "$pr_branch"
+
+          gh pr create \
+            --base main \
+            --head "$pr_branch" \
+            --title "docs: weekly Trivy security scan update" \
+            --body "Automated PR to update the Trivy vulnerability summary in the README governance evidence section."

--- a/.github/workflows/trivy-report.yml
+++ b/.github/workflows/trivy-report.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch: {}
   schedule:
     - cron: '0 0 * * 0'
+  pull_request:
+    types: [closed]
 
 permissions:
   contents: write
@@ -11,7 +13,7 @@ permissions:
 
 jobs:
   trivy-report:
-    if: github.repository == 'agslima/software-delivery-pipeline'
+    if: github.repository == 'agslima/software-delivery-pipeline' && github.event_name != 'pull_request'
     name: Update Trivy report in README
     runs-on: ubuntu-latest
     steps:
@@ -57,3 +59,23 @@ jobs:
             --head "$pr_branch" \
             --title "docs: weekly Trivy security scan update" \
             --body "Automated PR to update the Trivy vulnerability summary in the README governance evidence section."
+
+  cleanup-trivy-branches:
+    if: >-
+      github.repository == 'agslima/software-delivery-pipeline' &&
+      github.event_name == 'pull_request' &&
+      startsWith(github.event.pull_request.head.ref, 'trivy-update-') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    name: Cleanup closed Trivy update branches
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete branch for closed Trivy PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          echo "Deleting closed PR branch: ${BRANCH_NAME}"
+          gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BRANCH_NAME}" || {
+            echo "Branch may already be deleted; continuing."
+          }

--- a/hack/trivy-report.sh
+++ b/hack/trivy-report.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly FS_REPORT="/tmp/trivy-fs.json"
+readonly CONFIG_REPORT="/tmp/trivy-config.json"
+readonly TABLE_FILE="/tmp/trivy-table.md"
+
+README_FILE="README.md"
+if [[ ! -f "$README_FILE" && -f "readme.md" ]]; then
+  README_FILE="readme.md"
+fi
+
+if [[ ! -f "$README_FILE" ]]; then
+  echo "README file not found (checked README.md and readme.md)." >&2
+  exit 1
+fi
+
+if ! command -v trivy >/dev/null 2>&1; then
+  echo "Installing Trivy..."
+  curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /tmp/trivy-bin v0.48.3
+  export PATH="/tmp/trivy-bin:$PATH"
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required but not installed." >&2
+  exit 1
+fi
+
+echo "Running Trivy scans for app/..."
+trivy fs app --format json --output "$FS_REPORT" --scanners vuln || true
+trivy config app --format json --output "$CONFIG_REPORT" || true
+
+get_count() {
+  local file="$1"
+  local severity="$2"
+
+  jq "[
+    .Results[]? |
+    (
+      .Vulnerabilities[]? //
+      .Misconfigurations[]?
+    ) |
+    select(.Severity == \"${severity}\")
+  ] | length" "$file" 2>/dev/null || echo "0"
+}
+
+FS_CRIT="$(get_count "$FS_REPORT" "CRITICAL")"
+FS_HIGH="$(get_count "$FS_REPORT" "HIGH")"
+FS_MED="$(get_count "$FS_REPORT" "MEDIUM")"
+FS_LOW="$(get_count "$FS_REPORT" "LOW")"
+
+CFG_CRIT="$(get_count "$CONFIG_REPORT" "CRITICAL")"
+CFG_HIGH="$(get_count "$CONFIG_REPORT" "HIGH")"
+CFG_MED="$(get_count "$CONFIG_REPORT" "MEDIUM")"
+CFG_LOW="$(get_count "$CONFIG_REPORT" "LOW")"
+
+cat > "$TABLE_FILE" <<EOF_TABLE
+### Automated Trivy Security Posture (app/)
+
+This section is automatically refreshed by CI to provide governance evidence of the current vulnerability and configuration risk posture for the application surface in \
+\`app/\`.
+
+| Scan Target | Critical | High | Medium | Low |
+| :--- | :---: | :---: | :---: | :---: |
+| **Application Dependencies** (\`trivy fs app\`) | $FS_CRIT | $FS_HIGH | $FS_MED | $FS_LOW |
+| **Application Configuration** (\`trivy config app\`) | $CFG_CRIT | $CFG_HIGH | $CFG_MED | $CFG_LOW |
+
+*Last scanned (UTC): $(date -u +"%Y-%m-%d %H:%M")*
+EOF_TABLE
+
+echo "Injecting report into ${README_FILE}..."
+awk -v table_file="$TABLE_FILE" '
+  BEGIN {
+    in_block = 0
+    found_operational = 0
+    found_verification = 0
+  }
+
+  /^## Operational Evidence$/ {
+    print
+    print ""
+    while ((getline line < table_file) > 0) {
+      print line
+    }
+    close(table_file)
+    print ""
+    in_block = 1
+    found_operational = 1
+    next
+  }
+
+  /^## Verification \(How to Audit\)$/ {
+    in_block = 0
+    found_verification = 1
+    print
+    next
+  }
+
+  !in_block { print }
+
+  END {
+    if (!found_operational || !found_verification) {
+      print "Required README section headers not found." > "/dev/stderr"
+      exit 1
+    }
+  }
+' "$README_FILE" > "${README_FILE}.tmp"
+
+mv "${README_FILE}.tmp" "$README_FILE"
+echo "${README_FILE} updated successfully."

--- a/hack/trivy-report.sh
+++ b/hack/trivy-report.sh
@@ -31,6 +31,7 @@ echo "Running Trivy scans for app/..."
 trivy fs app --format json --output "$FS_REPORT" --scanners vuln || true
 trivy config app --format json --output "$CONFIG_REPORT" || true
 
+# get_count counts vulnerabilities or misconfigurations of the specified severity in a Trivy JSON report file and echoes the numeric count (prints `0` if the file is missing or cannot be parsed).
 get_count() {
   local file="$1"
   local severity="$2"

--- a/hack/trivy-report.sh
+++ b/hack/trivy-report.sh
@@ -16,9 +16,12 @@ if [[ ! -f "$README_FILE" ]]; then
   exit 1
 fi
 
+TRIVY_VERSION="${TRIVY_VERSION:-v0.69.3}"
+
 if ! command -v trivy >/dev/null 2>&1; then
-  echo "Installing Trivy..."
-  curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /tmp/trivy-bin v0.48.3
+  echo "Installing Trivy ${TRIVY_VERSION}..."
+  curl -sfL "https://raw.githubusercontent.com/aquasecurity/trivy/${TRIVY_VERSION}/contrib/install.sh" \
+    | sh -s -- -b /tmp/trivy-bin "${TRIVY_VERSION}"
   export PATH="/tmp/trivy-bin:$PATH"
 fi
 
@@ -27,9 +30,56 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
+validate_json_report() {
+  local report_file="$1"
+  local label="$2"
+
+  if [[ ! -s "$report_file" ]]; then
+    echo "Error: ${label} report was not created or is empty: ${report_file}" >&2
+    exit 1
+  fi
+
+  if ! jq empty "$report_file" >/dev/null 2>&1; then
+    echo "Error: ${label} report is not valid JSON: ${report_file}" >&2
+    exit 1
+  fi
+}
+
+run_trivy_scan() {
+  local label="$1"
+  local report_file="$2"
+  shift 2
+
+  local stderr_file
+  stderr_file="$(mktemp)"
+
+  echo "Running ${label} scan..."
+  local exit_code=0
+  if trivy "$@" --format json --output "$report_file" 2>"$stderr_file"; then
+    :
+  else
+    exit_code=$?
+    echo "Error: ${label} scan failed (exit code: ${exit_code})." >&2
+    if [[ -s "$stderr_file" ]]; then
+      echo "Trivy stderr (${label}):" >&2
+      sed "s/^/  /" "$stderr_file" >&2
+    fi
+    rm -f "$stderr_file"
+    exit "$exit_code"
+  fi
+
+  if [[ -s "$stderr_file" ]]; then
+    echo "Trivy stderr (${label}):" >&2
+    sed "s/^/  /" "$stderr_file" >&2
+  fi
+
+  rm -f "$stderr_file"
+  validate_json_report "$report_file" "$label"
+}
+
 echo "Running Trivy scans for app/..."
-trivy fs app --format json --output "$FS_REPORT" --scanners vuln || true
-trivy config app --format json --output "$CONFIG_REPORT" || true
+run_trivy_scan "filesystem vulnerabilities" "$FS_REPORT" fs app --scanners vuln
+run_trivy_scan "configuration" "$CONFIG_REPORT" config app
 
 # get_count counts vulnerabilities or misconfigurations of the specified severity in a Trivy JSON report file and echoes the numeric count (prints `0` if the file is missing or cannot be parsed).
 get_count() {
@@ -73,36 +123,64 @@ EOF_TABLE
 echo "Injecting report into ${README_FILE}..."
 awk -v table_file="$TABLE_FILE" '
   BEGIN {
-    in_block = 0
+    in_operational = 0
     found_operational = 0
     found_verification = 0
+    found_begin_marker = 0
+    found_end_marker = 0
   }
 
   /^## Operational Evidence$/ {
-    print
-    print ""
-    while ((getline line < table_file) > 0) {
-      print line
-    }
-    close(table_file)
-    print ""
-    in_block = 1
+    in_operational = 1
     found_operational = 1
+    print
     next
   }
 
   /^## Verification \(How to Audit\)$/ {
-    in_block = 0
+    if (in_operational && !found_end_marker) {
+      print "Generated table end marker not found before verification section." > "/dev/stderr"
+      exit 1
+    }
+
+    in_operational = 0
     found_verification = 1
     print
     next
   }
 
-  !in_block { print }
+  {
+    if (in_operational && /^<!-- \[BEGIN_GENERATED_TABLE\] -->$/) {
+      found_begin_marker = 1
+      print
+      while ((getline line < table_file) > 0) {
+        print line
+      }
+      close(table_file)
+      next
+    }
+
+    if (in_operational && /^<!-- \[END_GENERATED_TABLE\] -->$/) {
+      found_end_marker = 1
+      print
+      next
+    }
+
+    if (in_operational && found_begin_marker && !found_end_marker) {
+      next
+    }
+
+    print
+  }
 
   END {
     if (!found_operational || !found_verification) {
       print "Required README section headers not found." > "/dev/stderr"
+      exit 1
+    }
+
+    if (!found_begin_marker || !found_end_marker) {
+      print "Required generated table markers not found in Operational Evidence section." > "/dev/stderr"
       exit 1
     }
   }

--- a/readme.md
+++ b/readme.md
@@ -186,6 +186,7 @@ For more details on how branch protection, code ownership, and release integrity
 <!-- [BEGIN_GENERATED_TABLE] -->
 <!-- [END_GENERATED_TABLE] -->
 
+<!--
 ### Case Study: Legacy Risk Remediation 🔬
 
 To validate the effectiveness of the delivery control plane, a legacy application with known security debt was intentionally passed through the pipeline.
@@ -222,7 +223,7 @@ Screenshots below are from a legacy remediation exercise; current workflows use 
 | Initial Vulnerability Scan | Post-Fix Clean Scan |
 | --- | --- |
 | ![image](https://github.com/agslima/software-delivery-pipeline/blob/main/docs/images/scan-snyk-01.png) | ![image](https://github.com/agslima/software-delivery-pipeline/blob/main/docs/images/scan-snyk-02.png) |
-
+-->
 ---
 
 ## Verification (How to Audit)

--- a/readme.md
+++ b/readme.md
@@ -183,6 +183,9 @@ For more details on how branch protection, code ownership, and release integrity
 
 ## Operational Evidence
 
+<!-- [BEGIN_GENERATED_TABLE] -->
+<!-- [END_GENERATED_TABLE] -->
+
 ### Case Study: Legacy Risk Remediation 🔬
 
 To validate the effectiveness of the delivery control plane, a legacy application with known security debt was intentionally passed through the pipeline.

--- a/readme.md
+++ b/readme.md
@@ -218,7 +218,7 @@ Screenshots below are from a legacy remediation exercise; current workflows use 
 
 | Initial Vulnerability Scan | Post-Fix Clean Scan |
 | --- | --- |
-| ![image](https://github.com/agslima/secure-app-analysis/blob/main/docs/images/scan-snyk-01.png) | ![image](https://github.com/agslima/secure-app-analysis/blob/main/docs/images/scan-snyk-02.png) |
+| ![image](https://github.com/agslima/software-delivery-pipeline/blob/main/docs/images/scan-snyk-01.png) | ![image](https://github.com/agslima/software-delivery-pipeline/blob/main/docs/images/scan-snyk-02.png) |
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -183,10 +183,10 @@ For more details on how branch protection, code ownership, and release integrity
 
 ## Operational Evidence
 
-<!-- [BEGIN_GENERATED_TABLE] -->
-<!-- [END_GENERATED_TABLE] -->
+ <!-- [BEGIN_GENERATED_TABLE] -->
+> 📊 **Automated vulnerability report**: This section is automatically updated by the Trivy reporting workflow. Report generation is in progress or scheduled.
+ <!-- [END_GENERATED_TABLE] -->
 
-<!--
 ### Case Study: Legacy Risk Remediation 🔬
 
 To validate the effectiveness of the delivery control plane, a legacy application with known security debt was intentionally passed through the pipeline.
@@ -223,7 +223,7 @@ Screenshots below are from a legacy remediation exercise; current workflows use 
 | Initial Vulnerability Scan | Post-Fix Clean Scan |
 | --- | --- |
 | ![image](https://github.com/agslima/software-delivery-pipeline/blob/main/docs/images/scan-snyk-01.png) | ![image](https://github.com/agslima/software-delivery-pipeline/blob/main/docs/images/scan-snyk-02.png) |
--->
+
 ---
 
 ## Verification (How to Audit)


### PR DESCRIPTION
### Motivation
- Provide continuous governance evidence by automatically scanning the `app/` surface with Trivy and surfacing concise vulnerability counts in the repository README. 
- Ensure the report is auditable and visible to developers by injecting it into the documented governance area between `## Operational Evidence` and `## Verification (How to Audit)`.
- Keep the change minimal and reviewable by adding only a workflow and a small helper script without changing other CI or policy controls.

### Description
- Add a GitHub Actions workflow ` .github/workflows/trivy-report.yml` that runs on `workflow_dispatch` and weekly cron and has `contents: write` and `pull-requests: write` permissions to open an automated PR when the README changes. 
- Add `hack/trivy-report.sh` which installs Trivy if missing, runs `trivy fs app` and `trivy config app`, aggregates severity counts, generates a markdown summary, and injects that summary directly between the `## Operational Evidence` and `## Verification (How to Audit)` headers (with fallback to `readme.md` if present). 
- The workflow is fail-safe: if the script does not change the README, no PR is created; the script is intentionally focused on the `app/` scope only and does not alter any other governance/control logic. 
- Implementation follows repository guidance to make a small, auditable change inside the high-sensitivity workflows area while preserving existing protections and interfaces.

### Testing
- `bash -n hack/trivy-report.sh` was run to validate shell syntax and returned successfully.  
- Workflow YAML was parsed using Ruby (`require 'yaml'; YAML.load_file('.github/workflows/trivy-report.yml')`) and validated successfully.  
- An attempt to run `./hack/trivy-report.sh` in this environment failed during the Trivy installation step due to outbound/network limitations in the execution environment, which is an environment-specific limitation and not a failure of the script; the script is designed to run on GitHub-hosted runners where outbound access is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac94f531b4832d914c2b9b97722166)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated weekly (and manual) security scan that generates a timestamped vulnerabilities/configuration summary and injects a results table into the README.
  * Automatically opens a pull request when the README is updated, skips PR creation if unchanged, and cleans up temporary branches after PR closure.

* **Documentation**
  * Added workflow documentation, expanded the Evidence section with a case study and remediation narrative, and corrected image links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->