### PR TITLE
ci: set step env vars and add curl timeouts in ci-weekly-dast.yml

### DIFF
--- a/.github/workflows/ci-weekly-dast.yml
+++ b/.github/workflows/ci-weekly-dast.yml
@@ -73,6 +73,17 @@ jobs:
 
       - name: Set Variables + Compose Secrets (file-based)
         working-directory: app
+        env:
+          ADMIN_USER_VALUE: ${{ vars.ADMIN_USER }}
+          DB_USER_VALUE: ${{ vars.DB_USER }}
+          DB_NAME_VALUE: ${{ vars.DB_NAME }}
+          ADMIN_PASS_VALUE: ${{ secrets.ADMIN_PASS }}
+          DB_PASS_VALUE: ${{ secrets.DB_PASS }}
+          JWT_SECRET_VALUE: ${{ secrets.JWT_SECRET }}
+          DATA_ENCRYPTION_KEY_VALUE: ${{ secrets.DATA_ENCRYPTION_KEY }}
+          STEP_COMPOSE_PROJECT_NAME: ${{ env.COMPOSE_PROJECT_NAME }}
+          STEP_SEED_ADMIN_EMAIL: ${{ vars.ZAP_LOGIN_EMAIL }}
+          STEP_SEED_DEFAULT_PASSWORD: ${{ secrets.ZAP_LOGIN_PASSWORD }}
         run: |
           set -euo pipefail
 
@@ -83,14 +94,6 @@ jobs:
           rm -f "$ENV_FILE"
           rm -rf "$SECRETS_PATH"
           mkdir -p "$SECRETS_PATH"
-
-          ADMIN_USER_VALUE="${{ vars.ADMIN_USER }}"
-          DB_USER_VALUE="${{ vars.DB_USER }}"
-          DB_NAME_VALUE="${{ vars.DB_NAME }}"
-          ADMIN_PASS_VALUE="${{ secrets.ADMIN_PASS }}"
-          DB_PASS_VALUE="${{ secrets.DB_PASS }}"
-          JWT_SECRET_VALUE="${{ secrets.JWT_SECRET }}"
-          DATA_ENCRYPTION_KEY_VALUE="${{ secrets.DATA_ENCRYPTION_KEY }}"
 
           [ -n "$ADMIN_USER_VALUE" ] || ADMIN_USER_VALUE="admin"
           [ -n "$DB_USER_VALUE" ] || DB_USER_VALUE="postgres"
@@ -113,10 +116,10 @@ jobs:
             echo "DB_PASS=${DB_PASS_VALUE}"
             echo "JWT_SECRET=${JWT_SECRET_VALUE}"
             echo "DATA_ENCRYPTION_KEY=${DATA_ENCRYPTION_KEY_VALUE}"
-            echo "COMPOSE_PROJECT_NAME=${{ env.COMPOSE_PROJECT_NAME }}"
+            echo "COMPOSE_PROJECT_NAME=${STEP_COMPOSE_PROJECT_NAME}"
             echo "SECRETS_PATH=${SECRETS_PATH}"
-            echo "SEED_ADMIN_EMAIL=${{ vars.ZAP_LOGIN_EMAIL }}"
-            echo "SEED_DEFAULT_PASSWORD=${{ secrets.ZAP_LOGIN_PASSWORD }}"
+            echo "SEED_ADMIN_EMAIL=${STEP_SEED_ADMIN_EMAIL}"
+            echo "SEED_DEFAULT_PASSWORD=${STEP_SEED_DEFAULT_PASSWORD}"
           } >> "$ENV_FILE"
           chmod 600 "$ENV_FILE"
 
@@ -269,7 +272,7 @@ jobs:
           AUTH_HTTP_CODE=""
           RESP=""
           for attempt in 1 2 3 4 5; do
-            RESP="$(curl -sS -X POST "${LOGIN_URL}" -H "Content-Type: application/json" --data "$LOGIN_PAYLOAD" -w $'\n%{http_code}')"
+            RESP="$(curl -sS --connect-timeout 5 --max-time 20 -X POST "${LOGIN_URL}" -H "Content-Type: application/json" --data "$LOGIN_PAYLOAD" -w $'\n%{http_code}')"
             AUTH_HTTP_CODE="$(printf '%s' "$RESP" | tail -n 1)"
             RESP="$(printf '%s' "$RESP" | sed '$d')"
 
@@ -315,7 +318,7 @@ jobs:
           echo "DAST_AUTH_ASSERTION_PASSED=0" >> "$GITHUB_ENV"
 
           if [ -n "${AUTH_VERIFY_URL}" ]; then
-            curl -fsS -o /dev/null -H "Authorization: Bearer ${TOKEN}" "${AUTH_VERIFY_URL}"
+            curl -fsS --connect-timeout 5 --max-time 20 -o /dev/null -H "Authorization: Bearer ${TOKEN}" "${AUTH_VERIFY_URL}"
             echo "DAST_AUTH_ASSERTION_PASSED=1" >> "$GITHUB_ENV"
             echo "✅ Auth verification passed"
           else
@@ -449,7 +452,7 @@ jobs:
           AUTH_HTTP_CODE=""
           RESP=""
           for attempt in 1 2 3 4 5; do
-            RESP="$(curl -sS -X POST "${LOGIN_URL}" \
+            RESP="$(curl -sS --connect-timeout 5 --max-time 20 -X POST "${LOGIN_URL}" \
               -H "Content-Type: application/json" \
               --data "$LOGIN_PAYLOAD" \
               -w $'\n%{http_code}')"
@@ -494,7 +497,7 @@ jobs:
           echo "ZAP_AUTH_TOKEN=${TOKEN}" >> "$GITHUB_ENV"
 
           if [ -n "${AUTH_VERIFY_URL}" ]; then
-            curl -fsS -o /dev/null -H "Authorization: Bearer ${TOKEN}" "${AUTH_VERIFY_URL}"
+            curl -fsS --connect-timeout 5 --max-time 20 -o /dev/null -H "Authorization: Bearer ${TOKEN}" "${AUTH_VERIFY_URL}"
             echo "✅ Auth refresh verification passed"
           fi
 


### PR DESCRIPTION
### Motivation

- Ensure secrets and variables are injected reliably into the `Set Variables + Compose Secrets (file-based)` step by moving GH expressions into the step `env` block to avoid interpolation issues in the `run` shell block.
- Prevent workflow hangs and make HTTP auth calls more robust by adding timeouts to `curl` requests.
- Improve readability and masking consistency when writing the generated `.env` and secrets files.

### Description

- Added a step-level `env` mapping for `ADMIN_USER_VALUE`, `DB_USER_VALUE`, `DB_NAME_VALUE`, `ADMIN_PASS_VALUE`, `DB_PASS_VALUE`, `JWT_SECRET_VALUE`, `DATA_ENCRYPTION_KEY_VALUE`, `STEP_COMPOSE_PROJECT_NAME`, `STEP_SEED_ADMIN_EMAIL`, and `STEP_SEED_DEFAULT_PASSWORD` in `ci-weekly-dast.yml` so the shell `run` block reads these from the environment.
- Replaced inline GitHub Actions interpolation inside the `run` block with the new step env vars such as `STEP_COMPOSE_PROJECT_NAME`, `STEP_SEED_ADMIN_EMAIL`, and `STEP_SEED_DEFAULT_PASSWORD` when generating the `.env` file.
- Added `--connect-timeout 5 --max-time 20` to `curl` invocations used for auth bootstrap, auth refresh, and auth verification to avoid long hangs on network issues.

### Testing

- The change is limited to the `ci-weekly-dast.yml` workflow file and no application code or unit tests were modified. 
- The workflow YAML was updated and reviewed for syntax consistency and the `curl` timeout flags were applied to all relevant auth calls; no automated test failures were introduced. 
- CI will exercise the updated workflow on the next scheduled run to validate end-to-end behavior under GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af62bf3068832da4be6e707d567e6a)