### PR TITLE
fix: Enforce TLS & tighten OIDC auth; add tests, script hardening, client cert generation, and CI/k8s fixes

### DIFF
--- a/.github/workflows/ci-weekly-dast.yml
+++ b/.github/workflows/ci-weekly-dast.yml
@@ -73,6 +73,17 @@ jobs:
 
       - name: Set Variables + Compose Secrets (file-based)
         working-directory: app
+        env:
+          ADMIN_USER_VALUE: ${{ vars.ADMIN_USER }}
+          DB_USER_VALUE: ${{ vars.DB_USER }}
+          DB_NAME_VALUE: ${{ vars.DB_NAME }}
+          ADMIN_PASS_VALUE: ${{ secrets.ADMIN_PASS }}
+          DB_PASS_VALUE: ${{ secrets.DB_PASS }}
+          JWT_SECRET_VALUE: ${{ secrets.JWT_SECRET }}
+          DATA_ENCRYPTION_KEY_VALUE: ${{ secrets.DATA_ENCRYPTION_KEY }}
+          STEP_COMPOSE_PROJECT_NAME: ${{ env.COMPOSE_PROJECT_NAME }}
+          STEP_SEED_ADMIN_EMAIL: ${{ vars.ZAP_LOGIN_EMAIL }}
+          STEP_SEED_DEFAULT_PASSWORD: ${{ secrets.ZAP_LOGIN_PASSWORD }}
         run: |
           set -euo pipefail
 
@@ -83,14 +94,6 @@ jobs:
           rm -f "$ENV_FILE"
           rm -rf "$SECRETS_PATH"
           mkdir -p "$SECRETS_PATH"
-
-          ADMIN_USER_VALUE="${{ vars.ADMIN_USER }}"
-          DB_USER_VALUE="${{ vars.DB_USER }}"
-          DB_NAME_VALUE="${{ vars.DB_NAME }}"
-          ADMIN_PASS_VALUE="${{ secrets.ADMIN_PASS }}"
-          DB_PASS_VALUE="${{ secrets.DB_PASS }}"
-          JWT_SECRET_VALUE="${{ secrets.JWT_SECRET }}"
-          DATA_ENCRYPTION_KEY_VALUE="${{ secrets.DATA_ENCRYPTION_KEY }}"
 
           [ -n "$ADMIN_USER_VALUE" ] || ADMIN_USER_VALUE="admin"
           [ -n "$DB_USER_VALUE" ] || DB_USER_VALUE="postgres"
@@ -113,10 +116,10 @@ jobs:
             echo "DB_PASS=${DB_PASS_VALUE}"
             echo "JWT_SECRET=${JWT_SECRET_VALUE}"
             echo "DATA_ENCRYPTION_KEY=${DATA_ENCRYPTION_KEY_VALUE}"
-            echo "COMPOSE_PROJECT_NAME=${{ env.COMPOSE_PROJECT_NAME }}"
+            echo "COMPOSE_PROJECT_NAME=${STEP_COMPOSE_PROJECT_NAME}"
             echo "SECRETS_PATH=${SECRETS_PATH}"
-            echo "SEED_ADMIN_EMAIL=${{ vars.ZAP_LOGIN_EMAIL }}"
-            echo "SEED_DEFAULT_PASSWORD=${{ secrets.ZAP_LOGIN_PASSWORD }}"
+            echo "SEED_ADMIN_EMAIL=${STEP_SEED_ADMIN_EMAIL}"
+            echo "SEED_DEFAULT_PASSWORD=${STEP_SEED_DEFAULT_PASSWORD}"
           } >> "$ENV_FILE"
           chmod 600 "$ENV_FILE"
 
@@ -269,7 +272,7 @@ jobs:
           AUTH_HTTP_CODE=""
           RESP=""
           for attempt in 1 2 3 4 5; do
-            RESP="$(curl -sS -X POST "${LOGIN_URL}" -H "Content-Type: application/json" --data "$LOGIN_PAYLOAD" -w $'\n%{http_code}')"
+            RESP="$(curl -sS --connect-timeout 5 --max-time 20 -X POST "${LOGIN_URL}" -H "Content-Type: application/json" --data "$LOGIN_PAYLOAD" -w $'\n%{http_code}')"
             AUTH_HTTP_CODE="$(printf '%s' "$RESP" | tail -n 1)"
             RESP="$(printf '%s' "$RESP" | sed '$d')"
 
@@ -315,7 +318,7 @@ jobs:
           echo "DAST_AUTH_ASSERTION_PASSED=0" >> "$GITHUB_ENV"
 
           if [ -n "${AUTH_VERIFY_URL}" ]; then
-            curl -fsS -o /dev/null -H "Authorization: Bearer ${TOKEN}" "${AUTH_VERIFY_URL}"
+            curl -fsS --connect-timeout 5 --max-time 20 -o /dev/null -H "Authorization: Bearer ${TOKEN}" "${AUTH_VERIFY_URL}"
             echo "DAST_AUTH_ASSERTION_PASSED=1" >> "$GITHUB_ENV"
             echo "✅ Auth verification passed"
           else
@@ -449,7 +452,7 @@ jobs:
           AUTH_HTTP_CODE=""
           RESP=""
           for attempt in 1 2 3 4 5; do
-            RESP="$(curl -sS -X POST "${LOGIN_URL}" \
+            RESP="$(curl -sS --connect-timeout 5 --max-time 20 -X POST "${LOGIN_URL}" \
               -H "Content-Type: application/json" \
               --data "$LOGIN_PAYLOAD" \
               -w $'\n%{http_code}')"
@@ -494,7 +497,7 @@ jobs:
           echo "ZAP_AUTH_TOKEN=${TOKEN}" >> "$GITHUB_ENV"
 
           if [ -n "${AUTH_VERIFY_URL}" ]; then
-            curl -fsS -o /dev/null -H "Authorization: Bearer ${TOKEN}" "${AUTH_VERIFY_URL}"
+            curl -fsS --connect-timeout 5 --max-time 20 -o /dev/null -H "Authorization: Bearer ${TOKEN}" "${AUTH_VERIFY_URL}"
             echo "✅ Auth refresh verification passed"
           fi
 

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -14,3 +14,4 @@ c82f02db4c338ae2f5b40a012eec84e2b28c1186:app/logs:curl-auth-header:64
 0faabf03109cde262b8c4a2b00ab6352934dbff3:app/TO-DO-DEMO-P2.md:curl-auth-header:87
 0faabf03109cde262b8c4a2b00ab6352934dbff3:app/TO-DO-DEMO-P2.md:curl-auth-header:100
 0faabf03109cde262b8c4a2b00ab6352934dbff3:app/TO-DO-DEMO-P2.md:curl-auth-header:123
+17a9731a5f6ad6bd0dbd574eff3f9743eea96385:app/server/tests/unit/api.v2.coverage.test.js:generic-api-key:95

--- a/app/client/src/App.jsx
+++ b/app/client/src/App.jsx
@@ -12,11 +12,11 @@ import PatientLogin from './components/PatientLogin';
 import PatientPortal from './components/PatientPortal';
 import './styles/Portal.css';
 
-const SESSION_KEY = 'stayhealthy_patient_session';
+const sessionStorageKey = import.meta.env.VITE_PATIENT_PORTAL_SESSION_STORAGE_KEY || 'patient_portal_session';
 
 const readSession = () => {
   try {
-    const raw = sessionStorage.getItem(SESSION_KEY);
+    const raw = sessionStorage.getItem(sessionStorageKey);
     return raw ? JSON.parse(raw) : null;
   } catch {
     return null;
@@ -42,9 +42,9 @@ export default function App() {
 
   useEffect(() => {
     if (session) {
-      sessionStorage.setItem(SESSION_KEY, JSON.stringify(session));
+      sessionStorage.setItem(sessionStorageKey, JSON.stringify(session));
     } else {
-      sessionStorage.removeItem(SESSION_KEY);
+      sessionStorage.removeItem(sessionStorageKey);
     }
   }, [session]);
 

--- a/app/client/src/App.test.jsx
+++ b/app/client/src/App.test.jsx
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event';
 import App from './App';
 import * as api from './api/patientPortalApi';
 
-// Mock the API module
 vi.mock('./api/patientPortalApi');
 
 const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
@@ -84,14 +83,12 @@ describe('App Integration', () => {
 
     render(<App />);
 
-    // Perform Login
     await user.type(screen.getByLabelText(/email/i), email);
     await user.type(screen.getByLabelText(/password/i), password);
     await user.click(screen.getByRole('button', { name: /secure login/i }));
 
     expect(await screen.findByText(/prescription history/i)).toBeInTheDocument();
 
-    // Verify Data Rendered
     await waitFor(() => {
       expect(screen.getAllByText('Dr. Emily Johnson').length).toBeGreaterThan(0);
     });
@@ -115,9 +112,59 @@ describe('App Integration', () => {
     await user.type(screen.getByLabelText(/password/i), password);
     await user.click(screen.getByRole('button', { name: /secure login/i }));
 
-    // Wait for the error banner
     await waitFor(() => {
       expect(screen.getByText(/unable to load prescriptions/i)).toBeInTheDocument();
     });
+  });
+
+  it('handles MFA-required login and completes MFA verification', async () => {
+    const user = userEvent.setup();
+    const email = buildTestEmail('mfa');
+    const password = buildTestPassword();
+
+    api.loginPatient.mockResolvedValue({
+      mfaRequired: true,
+      mfaToken: 'mfa-token-1',
+      user: { id: 'patient-2', email, role: 'patient', mfaEnabled: true },
+    });
+    api.verifyMfa.mockResolvedValue({ token: 'token-after-mfa' });
+    api.getMyPrescriptions.mockResolvedValue({ prescriptions: [mockSummary] });
+    api.getMyPrescription.mockResolvedValue(mockDetail);
+
+    render(<App />);
+
+    await user.type(screen.getByLabelText(/email/i), email);
+    await user.type(screen.getByLabelText(/password/i), password);
+    await user.click(screen.getByRole('button', { name: /secure login/i }));
+
+    expect(await screen.findByText(/two-factor verification/i)).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/verification code/i), '123456');
+    await user.click(screen.getByRole('button', { name: /^verify$/i }));
+
+    await waitFor(() => {
+      expect(api.verifyMfa).toHaveBeenCalledWith('123456', 'mfa-token-1');
+    });
+    expect(await screen.findByText(/prescription history/i)).toBeInTheDocument();
+  });
+
+  it('returns to login when prescriptions call reports SESSION_EXPIRED', async () => {
+    const user = userEvent.setup();
+    const email = buildTestEmail('expired');
+    const password = buildTestPassword();
+
+    api.loginPatient.mockResolvedValue({
+      token: 'expired-token',
+      user: { id: 'patient-3', email, role: 'patient', mfaEnabled: false },
+    });
+    api.getMyPrescriptions.mockRejectedValue(new Error('SESSION_EXPIRED'));
+
+    render(<App />);
+
+    await user.type(screen.getByLabelText(/email/i), email);
+    await user.type(screen.getByLabelText(/password/i), password);
+    await user.click(screen.getByRole('button', { name: /secure login/i }));
+
+    expect(await screen.findByText(/patient prescription portal/i)).toBeInTheDocument();
   });
 });

--- a/app/client/src/api/patientPortalApi.test.js
+++ b/app/client/src/api/patientPortalApi.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  loginPatient,
+  verifyMfa,
+  getMyPrescriptions,
+  getMyPrescription,
+  getMfaStatus,
+  enrollMfa,
+  disableMfa,
+} from './patientPortalApi';
+
+describe('patientPortalApi', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('loginPatient returns token payload on success', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ accessToken: 'jwt-1', user: { id: 'p-1' } }),
+    });
+
+    await expect(loginPatient('patient@example.test', 'Password123!')).resolves.toEqual({
+      token: 'jwt-1',
+      user: { id: 'p-1' },
+    });
+  });
+
+  it('loginPatient returns MFA challenge and maps failures', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ mfaRequired: true, mfaToken: 'mfa-1', user: { id: 'p-1' } }),
+    });
+    await expect(loginPatient('patient@example.test', 'Password123!')).resolves.toEqual({
+      mfaRequired: true,
+      mfaToken: 'mfa-1',
+      user: { id: 'p-1' },
+    });
+
+    fetch.mockResolvedValueOnce({ ok: false, status: 401 });
+    await expect(loginPatient('patient@example.test', 'bad-pass')).rejects.toMatchObject({
+      message: 'INCORRECT_CREDENTIALS',
+    });
+
+    fetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    await expect(loginPatient('patient@example.test', 'bad-pass')).rejects.toMatchObject({
+      message: 'SERVER_ERROR',
+    });
+
+    fetch.mockRejectedValueOnce(new Error('Failed to fetch'));
+    await expect(loginPatient('patient@example.test', 'bad-pass')).rejects.toMatchObject({
+      message: 'NETWORK_ERROR',
+    });
+  });
+
+  it('verifyMfa returns token payload and maps 400/network errors', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ accessToken: 'jwt-2', refreshToken: 'r-1' }),
+    });
+
+    await expect(verifyMfa('123456', 'mfa-token')).resolves.toEqual({
+      token: 'jwt-2',
+      refreshToken: 'r-1',
+    });
+
+    fetch.mockResolvedValueOnce({ ok: false, status: 400 });
+    await expect(verifyMfa('000000', 'mfa-token')).rejects.toMatchObject({ message: 'INVALID_MFA_CODE' });
+
+    fetch.mockRejectedValueOnce(new Error('NetworkError when attempting to fetch resource'));
+    await expect(verifyMfa('000000', 'mfa-token')).rejects.toMatchObject({ message: 'NETWORK_ERROR' });
+  });
+
+  it('maps status codes for list/detail endpoints', async () => {
+    fetch.mockResolvedValueOnce({ ok: true, status: 200, json: vi.fn().mockResolvedValue({ prescriptions: [] }) });
+    await expect(getMyPrescriptions('jwt')).resolves.toEqual({ prescriptions: [] });
+
+    fetch.mockResolvedValueOnce({ ok: false, status: 401 });
+    await expect(getMyPrescriptions('jwt')).rejects.toMatchObject({ message: 'SESSION_EXPIRED' });
+
+    fetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    await expect(getMyPrescriptions('jwt')).rejects.toMatchObject({ message: 'SERVER_ERROR' });
+
+    fetch.mockResolvedValueOnce({ ok: false, status: 403 });
+    await expect(getMyPrescription('rx-1', 'jwt')).rejects.toMatchObject({ message: 'FORBIDDEN' });
+
+    fetch.mockResolvedValueOnce({ ok: false, status: 404 });
+    await expect(getMyPrescription('rx-1', 'jwt')).rejects.toMatchObject({ message: 'NOT_FOUND' });
+  });
+
+  it('maps MFA status/enroll/disable success and auth failures', async () => {
+    fetch.mockResolvedValueOnce({ ok: true, status: 200, json: vi.fn().mockResolvedValue({ enabled: true }) });
+    await expect(getMfaStatus('jwt')).resolves.toEqual({ enabled: true });
+
+    fetch.mockResolvedValueOnce({ ok: false, status: 401 });
+    await expect(getMfaStatus('jwt')).rejects.toMatchObject({ message: 'SESSION_EXPIRED' });
+
+    fetch.mockResolvedValueOnce({ ok: true, status: 200, json: vi.fn().mockResolvedValue({ secret: 'ABC' }) });
+    await expect(enrollMfa('jwt', 'phone')).resolves.toEqual({ secret: 'ABC' });
+
+    fetch.mockResolvedValueOnce({ ok: false, status: 401 });
+    await expect(enrollMfa('jwt', 'phone')).rejects.toMatchObject({ message: 'SESSION_EXPIRED' });
+
+    fetch.mockResolvedValueOnce({ ok: true, status: 200, json: vi.fn().mockResolvedValue({ ok: true }) });
+    await expect(disableMfa('jwt')).resolves.toEqual({ ok: true });
+
+    fetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    await expect(disableMfa('jwt')).rejects.toMatchObject({ message: 'SERVER_ERROR' });
+  });
+});

--- a/app/client/src/api/prescriptionApi.test.js
+++ b/app/client/src/api/prescriptionApi.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { login, getPrescription } from './prescriptionApi';
+
+describe('prescriptionApi', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  describe('login', () => {
+    it('returns token on successful login', async () => {
+      fetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({ token: 'token-123' }),
+      });
+
+      const token = await login('admin', 'secret');
+
+      expect(fetch).toHaveBeenCalledWith('/api/v1/auth/login',
+        expect.objectContaining({ method: 'POST' }));
+      expect(token).toBe('token-123');
+    });
+
+    it('throws INCORRECT_CREDENTIALS for 401', async () => {
+      fetch.mockResolvedValue({ ok: false, status: 401 });
+
+      await expect(login('admin', 'wrong')).rejects.toThrow('INCORRECT_CREDENTIALS');
+    });
+
+    it('throws SERVER_ERROR for non-401 unsuccessful responses', async () => {
+      fetch.mockResolvedValue({ ok: false, status: 500 });
+
+      await expect(login('admin', 'secret')).rejects.toThrow('SERVER_ERROR');
+    });
+
+    it('maps network failures to NETWORK_ERROR', async () => {
+      fetch.mockRejectedValue(new Error('Failed to fetch'));
+
+      await expect(login('admin', 'secret')).rejects.toThrow('NETWORK_ERROR');
+    });
+  });
+
+  describe('getPrescription', () => {
+    it('returns parsed prescription JSON on success', async () => {
+      const mockData = { id: 'rx-1', status: 'active' };
+      fetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue(mockData),
+      });
+
+      const result = await getPrescription('rx-1', 'token-1');
+
+      expect(fetch).toHaveBeenCalledWith('/api/v1/prescriptions/rx-1', {
+        headers: { Authorization: 'Bearer token-1' },
+      });
+      expect(result).toEqual(mockData);
+    });
+
+    it('throws SESSION_EXPIRED on 401 response', async () => {
+      fetch.mockResolvedValue({ ok: false, status: 401 });
+
+      await expect(getPrescription('rx-2', 'token-2')).rejects.toThrow('SESSION_EXPIRED');
+    });
+
+    it('throws SERVER_ERROR on non-401 error responses', async () => {
+      fetch.mockResolvedValue({ ok: false, status: 403 });
+
+      await expect(getPrescription('rx-3', 'token-3')).rejects.toThrow('SERVER_ERROR');
+    });
+  });
+});

--- a/app/client/src/components/PatientLogin.test.jsx
+++ b/app/client/src/components/PatientLogin.test.jsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '../test-utils';
+import userEvent from '@testing-library/user-event';
+import PatientLogin from './PatientLogin';
+
+describe('PatientLogin Component', () => {
+  it('submits email/password to onLogin', async () => {
+    const user = userEvent.setup();
+    const onLogin = vi.fn().mockResolvedValue(undefined);
+
+    render(<PatientLogin onLogin={onLogin} />);
+
+    await user.type(screen.getByLabelText(/email/i), 'patient@test.invalid');
+    await user.type(screen.getByLabelText(/password/i), 'Secret123!');
+    await user.click(screen.getByRole('button', { name: /secure login/i }));
+
+    await waitFor(() => {
+      expect(onLogin).toHaveBeenCalledWith('patient@test.invalid', 'Secret123!');
+    });
+  });
+
+  it('shows incorrect-credentials error message', async () => {
+    const user = userEvent.setup();
+    const onLogin = vi.fn().mockRejectedValue(new Error('INCORRECT_CREDENTIALS'));
+
+    render(<PatientLogin onLogin={onLogin} />);
+
+    await user.type(screen.getByLabelText(/email/i), 'bad@test.invalid');
+    await user.type(screen.getByLabelText(/password/i), 'wrong');
+    await user.click(screen.getByRole('button', { name: /secure login/i }));
+
+    expect(await screen.findByText(/incorrect email or password/i)).toBeInTheDocument();
+  });
+
+  it('shows generic error for unexpected login failures', async () => {
+    const user = userEvent.setup();
+    const onLogin = vi.fn().mockRejectedValue(new Error('SERVER_ERROR'));
+
+    render(<PatientLogin onLogin={onLogin} />);
+
+    await user.type(screen.getByLabelText(/email/i), 'user@test.invalid');
+    await user.type(screen.getByLabelText(/password/i), 'pass');
+    await user.click(screen.getByRole('button', { name: /secure login/i }));
+
+    expect(await screen.findByText(/something went wrong/i)).toBeInTheDocument();
+  });
+
+  it('renders MFA form, verifies code, and allows cancel', async () => {
+    const user = userEvent.setup();
+    const onVerifyMfa = vi.fn().mockResolvedValue(undefined);
+    const onCancelMfa = vi.fn();
+
+    render(
+      <PatientLogin
+        onLogin={vi.fn()}
+        onVerifyMfa={onVerifyMfa}
+        onCancelMfa={onCancelMfa}
+        mfaChallenge={{ mfaToken: 'token-1', user: { id: 'u1' } }}
+      />
+    );
+
+    await user.type(screen.getByLabelText(/verification code/i), '654321');
+    await user.click(screen.getByRole('button', { name: /^verify$/i }));
+
+    await waitFor(() => {
+      expect(onVerifyMfa).toHaveBeenCalledWith('654321');
+    });
+
+    await user.click(screen.getByRole('button', { name: /back to sign in/i }));
+    expect(onCancelMfa).toHaveBeenCalled();
+  });
+
+  it('shows invalid MFA code message on verification failure', async () => {
+    const user = userEvent.setup();
+    const onVerifyMfa = vi.fn().mockRejectedValue(new Error('INVALID_MFA_CODE'));
+
+    render(
+      <PatientLogin
+        onLogin={vi.fn()}
+        onVerifyMfa={onVerifyMfa}
+        onCancelMfa={vi.fn()}
+        mfaChallenge={{ mfaToken: 'token-1', user: { id: 'u1' } }}
+      />
+    );
+
+    await user.type(screen.getByLabelText(/verification code/i), '000000');
+    await user.click(screen.getByRole('button', { name: /^verify$/i }));
+
+    expect(await screen.findByText(/invalid verification code/i)).toBeInTheDocument();
+  });
+});

--- a/app/docker/Dockerfile.client
+++ b/app/docker/Dockerfile.client
@@ -45,16 +45,14 @@ RUN apk update && apk upgrade --no-cache \
                 /tmp/uwsgi_temp \
                 /tmp/scgi_temp \
                 /etc/nginx/certs \
-    && openssl req -x509 -nodes -newkey rsa:2048 -days 3650 \
-        -subj "/CN=localhost" \
-        -keyout /etc/nginx/certs/tls.key \
-        -out /etc/nginx/certs/tls.crt \
-    && chmod 600 /etc/nginx/certs/tls.key \
     && chown -R nginx:nginx /tmp /etc/nginx/certs \
-    && apk del openssl \
     && chmod -R 700 /tmp/*
 
 USER nginx
+
+
+COPY docker/generate-client-cert.sh /docker-entrypoint.d/50-generate-client-cert.sh
+RUN chmod 755 /docker-entrypoint.d/50-generate-client-cert.sh
 
 # Copy config
 COPY nginx/nginx.conf /etc/nginx/nginx.conf

--- a/app/docker/generate-client-cert.sh
+++ b/app/docker/generate-client-cert.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+set -eu
+
+CERT_DIR="/etc/nginx/certs"
+CERT_FILE="${CERT_DIR}/tls.crt"
+KEY_FILE="${CERT_DIR}/tls.key"
+
+if [ -s "$CERT_FILE" ] && [ -s "$KEY_FILE" ]; then
+  exit 0
+fi
+
+mkdir -p "$CERT_DIR"
+umask 077
+
+openssl req -x509 -nodes -newkey rsa:2048 -days 3650 \
+  -subj "/CN=localhost" \
+  -keyout "$KEY_FILE" \
+  -out "$CERT_FILE" >/dev/null 2>&1

--- a/app/scripts/backup-db.sh
+++ b/app/scripts/backup-db.sh
@@ -30,13 +30,13 @@ mkdir -p "$BACKUP_DIR"
 require_command pg_dump
 
 run_pg_dump_direct() {
-  if [ -n "${DB_PASS_FILE:-}" ] && [ -z "${DB_PASS:-}" ]; then
+  if [[ -n "${DB_PASS_FILE:-}" ]] && [[ -z "${DB_PASS:-}" ]]; then
     DB_PASS="$(cat "${DB_PASS_FILE}")"
-  elif [ -z "${DB_PASS:-}" ] && [ -f "${APP_DIR}/secrets/db_pass.txt" ]; then
+  elif [[ -z "${DB_PASS:-}" ]] && [[ -f "${APP_DIR}/secrets/db_pass.txt" ]]; then
     DB_PASS="$(cat "${APP_DIR}/secrets/db_pass.txt")"
   fi
 
-  if [ -z "${DB_PASS:-}" ]; then
+  if [[ -z "${DB_PASS:-}" ]]; then
     echo "DB_PASS or DB_PASS_FILE is required for direct mode." >&2
     exit 1
   fi
@@ -52,17 +52,17 @@ run_pg_dump_compose() {
 
 printf "Creating backup at %s...\n" "$BACKUP_PATH"
 
-if [ "$MODE" = "direct" ]; then
+if [[ "$MODE" = "direct" ]]; then
   run_pg_dump_direct
 else
   run_pg_dump_compose
 fi
 
-if [ -n "${BACKUP_ENCRYPTION_KEY_FILE:-}" ] && [ -z "${BACKUP_ENCRYPTION_KEY:-}" ]; then
+if [[ -n "${BACKUP_ENCRYPTION_KEY_FILE:-}" ]] && [[ -z "${BACKUP_ENCRYPTION_KEY:-}" ]]; then
   BACKUP_ENCRYPTION_KEY="$(cat "${BACKUP_ENCRYPTION_KEY_FILE}")"
 fi
 
-if [ -n "${BACKUP_ENCRYPTION_KEY:-}" ]; then
+if [[ -n "${BACKUP_ENCRYPTION_KEY:-}" ]]; then
   require_command openssl
   openssl enc -aes-256-gcm -salt -pbkdf2 -iter 100000 \
     -pass "pass:${BACKUP_ENCRYPTION_KEY}" \
@@ -72,7 +72,7 @@ if [ -n "${BACKUP_ENCRYPTION_KEY:-}" ]; then
   BACKUP_PATH="${BACKUP_PATH}.enc"
   printf "Encrypted backup written to %s\n" "$BACKUP_PATH"
 else
-  if [ "${BACKUP_REQUIRE_ENCRYPTION:-false}" = "true" ]; then
+  if [[ "${BACKUP_REQUIRE_ENCRYPTION:-false}" = "true" ]]; then
     echo "BACKUP_REQUIRE_ENCRYPTION=true but no BACKUP_ENCRYPTION_KEY provided." >&2
     exit 1
   fi

--- a/app/scripts/build-release-images.sh
+++ b/app/scripts/build-release-images.sh
@@ -49,7 +49,7 @@ else
   printf "syft not found; skipping SBOM generation.\n"
 fi
 
-if [ "$SIGN_IMAGES" = "true" ]; then
+if [[ "$SIGN_IMAGES" = "true" ]]; then
   if command -v cosign >/dev/null 2>&1; then
     printf "Signing images...\n"
     cosign sign --yes "$BACKEND_IMAGE"

--- a/app/scripts/phase2_e2e.sh
+++ b/app/scripts/phase2_e2e.sh
@@ -102,10 +102,10 @@ request() {
   local token="${4:-}"
 
   local args=(-s -S -w "\n%{http_code}" -X "$method" "${BASE_URL}${path}")
-  if [ -n "$token" ]; then
+  if [[ -n "$token" ]]; then
     args+=(-H "Authorization: Bearer ${token}")
   fi
-  if [ -n "$data" ]; then
+  if [[ -n "$data" ]]; then
     args+=(-H "Content-Type: application/json" -d "$data")
   fi
 
@@ -117,7 +117,7 @@ request() {
 
 assert_status() {
   local expected="$1"
-  if [ "$RESP_STATUS" != "$expected" ]; then
+  if [[ "$RESP_STATUS" != "$expected" ]]; then
     echo "Expected HTTP $expected, got $RESP_STATUS"
     echo "$RESP_BODY"
     exit 1
@@ -128,7 +128,7 @@ log "Patient login"
 request POST "/api/v2/auth/login" "{\"email\":\"${PATIENT_EMAIL}\",\"password\":\"${PATIENT_PASSWORD}\"}"
 assert_status 200
 MFA_REQUIRED=$(echo "$RESP_BODY" | json_get mfaRequired || true)
-if [ "$MFA_REQUIRED" = "True" ] || [ "$MFA_REQUIRED" = "true" ]; then
+if [[ "$MFA_REQUIRED" = "True" || "$MFA_REQUIRED" = "true" ]]; then
   echo "Patient login requires MFA. This script cannot proceed without a current TOTP code."
   exit 2
 fi
@@ -138,7 +138,7 @@ log "Patient prescriptions list"
 request GET "/api/v2/patient/me/prescriptions" "" "$PATIENT_TOKEN"
 assert_status 200
 FIRST_PRESCRIPTION_ID=$(echo "$RESP_BODY" | json_get prescriptions.0.id || true)
-if [ -n "$FIRST_PRESCRIPTION_ID" ]; then
+if [[ -n "$FIRST_PRESCRIPTION_ID" ]]; then
   log "Patient prescription detail"
   request GET "/api/v2/patient/me/prescriptions/${FIRST_PRESCRIPTION_ID}" "" "$PATIENT_TOKEN"
   assert_status 200
@@ -150,12 +150,12 @@ log "Patient MFA status"
 request GET "/api/v2/auth/mfa/status" "" "$PATIENT_TOKEN"
 assert_status 200
 
-if [ "$ENROLL_MFA" = "1" ]; then
+if [[ "$ENROLL_MFA" = "1" ]]; then
   log "Enroll MFA"
   request POST "/api/v2/auth/mfa/enroll" "{\"label\":\"${PATIENT_EMAIL}\"}" "$PATIENT_TOKEN"
   assert_status 200
   MFA_SECRET=$(echo "$RESP_BODY" | json_get secret)
-  if [ -n "$MFA_SECRET" ]; then
+  if [[ -n "$MFA_SECRET" ]]; then
     CODE=$(totp_code "$MFA_SECRET")
     log "Verify MFA"
     request POST "/api/v2/auth/mfa/verify" "{\"code\":\"${CODE}\"}" "$PATIENT_TOKEN"
@@ -171,7 +171,7 @@ log "Doctor login"
 request POST "/api/v2/auth/login" "{\"email\":\"${DOCTOR_EMAIL}\",\"password\":\"${DOCTOR_PASSWORD}\"}"
 assert_status 200
 DOC_MFA_REQUIRED=$(echo "$RESP_BODY" | json_get mfaRequired || true)
-if [ "$DOC_MFA_REQUIRED" = "True" ] || [ "$DOC_MFA_REQUIRED" = "true" ]; then
+if [[ "$DOC_MFA_REQUIRED" = "True" || "$DOC_MFA_REQUIRED" = "true" ]]; then
   echo "Doctor login requires MFA. This script cannot proceed without a current TOTP code."
   exit 2
 fi
@@ -185,7 +185,7 @@ log "Patient search"
 request GET "/api/v2/patients/search?name=John" "" "$DOCTOR_TOKEN"
 assert_status 200
 PATIENT_ID=$(echo "$RESP_BODY" | json_get results.0.id || true)
-if [ -z "$PATIENT_ID" ]; then
+if [[ -z "$PATIENT_ID" ]]; then
   PATIENT_ID="$DEFAULT_PATIENT_ID"
 fi
 
@@ -197,7 +197,7 @@ log "Medication search"
 request GET "/api/v2/medications?query=Amox" "" "$DOCTOR_TOKEN"
 assert_status 200
 MEDICATION_ID=$(echo "$RESP_BODY" | json_get results.0.id || true)
-if [ -z "$MEDICATION_ID" ]; then
+if [[ -z "$MEDICATION_ID" ]]; then
   MEDICATION_ID="$DEFAULT_MEDICATION_ID"
 fi
 
@@ -211,7 +211,7 @@ request POST "/api/v2/prescriptions" "{\"patientId\":\"${PATIENT_ID}\",\"encount
 assert_status 201
 PRESCRIPTION_ID=$(echo "$RESP_BODY" | json_get id || true)
 
-if [ -n "$PRESCRIPTION_ID" ]; then
+if [[ -n "$PRESCRIPTION_ID" ]]; then
   log "Update prescription"
   request PATCH "/api/v2/prescriptions/${PRESCRIPTION_ID}" "{\"status\":\"completed\"}" "$DOCTOR_TOKEN"
   assert_status 200
@@ -221,7 +221,7 @@ log "Admin login"
 request POST "/api/v2/auth/login" "{\"email\":\"${ADMIN_EMAIL}\",\"password\":\"${ADMIN_PASSWORD}\"}"
 assert_status 200
 ADMIN_MFA_REQUIRED=$(echo "$RESP_BODY" | json_get mfaRequired || true)
-if [ "$ADMIN_MFA_REQUIRED" = "True" ] || [ "$ADMIN_MFA_REQUIRED" = "true" ]; then
+if [[ "$ADMIN_MFA_REQUIRED" = "True" || "$ADMIN_MFA_REQUIRED" = "true" ]]; then
   echo "Admin login requires MFA. This script cannot proceed without a current TOTP code."
   exit 2
 fi

--- a/app/scripts/pin-release-images.sh
+++ b/app/scripts/pin-release-images.sh
@@ -23,7 +23,7 @@ resolve_digest() {
   local digest
   docker pull "$image" >/dev/null
   digest=$(docker inspect --format='{{index .RepoDigests 0}}' "$image")
-  if [ -z "$digest" ]; then
+  if [[ -z "$digest" ]]; then
     echo "Failed to resolve digest for $image" >&2
     exit 1
   fi

--- a/app/scripts/restore-db.sh
+++ b/app/scripts/restore-db.sh
@@ -22,12 +22,12 @@ require_command() {
   fi
 }
 
-if [ -z "$BACKUP_FILE" ]; then
+if [[ -z "$BACKUP_FILE" ]]; then
   echo "Usage: $0 /path/to/backup.dump[.enc]" >&2
   exit 1
 fi
 
-if [ "${CONFIRM_RESTORE:-false}" != "true" ]; then
+if [[ "${CONFIRM_RESTORE:-false}" != "true" ]]; then
   echo "Refusing to restore without CONFIRM_RESTORE=true" >&2
   exit 1
 fi
@@ -35,7 +35,7 @@ fi
 TEMP_FILE=""
 
 cleanup() {
-  if [ -n "$TEMP_FILE" ] && [ -f "$TEMP_FILE" ]; then
+  if [[ -n "$TEMP_FILE" && -f "$TEMP_FILE" ]]; then
     rm -f "$TEMP_FILE"
   fi
 }
@@ -43,11 +43,11 @@ cleanup() {
 trap cleanup EXIT
 
 if [[ "$BACKUP_FILE" == *.enc ]]; then
-  if [ -n "${BACKUP_ENCRYPTION_KEY_FILE:-}" ] && [ -z "${BACKUP_ENCRYPTION_KEY:-}" ]; then
+  if [[ -n "${BACKUP_ENCRYPTION_KEY_FILE:-}" && -z "${BACKUP_ENCRYPTION_KEY:-}" ]]; then
     BACKUP_ENCRYPTION_KEY="$(cat "${BACKUP_ENCRYPTION_KEY_FILE}")"
   fi
 
-  if [ -z "${BACKUP_ENCRYPTION_KEY:-}" ]; then
+  if [[ -z "${BACKUP_ENCRYPTION_KEY:-}" ]]; then
     echo "BACKUP_ENCRYPTION_KEY is required to decrypt backup." >&2
     exit 1
   fi
@@ -64,13 +64,13 @@ fi
 require_command pg_restore
 
 restore_direct() {
-  if [ -n "${DB_PASS_FILE:-}" ] && [ -z "${DB_PASS:-}" ]; then
+  if [[ -n "${DB_PASS_FILE:-}" && -z "${DB_PASS:-}" ]]; then
     DB_PASS="$(cat "${DB_PASS_FILE}")"
-  elif [ -z "${DB_PASS:-}" ] && [ -f "${APP_DIR}/secrets/db_pass.txt" ]; then
+  elif [[ -z "${DB_PASS:-}" && -f "${APP_DIR}/secrets/db_pass.txt" ]]; then
     DB_PASS="$(cat "${APP_DIR}/secrets/db_pass.txt")"
   fi
 
-  if [ -z "${DB_PASS:-}" ]; then
+  if [[ -z "${DB_PASS:-}" ]]; then
     echo "DB_PASS or DB_PASS_FILE is required for direct mode." >&2
     exit 1
   fi
@@ -87,7 +87,7 @@ restore_compose() {
 
 printf "Restoring backup %s into %s...\n" "$BACKUP_FILE" "$DB_NAME"
 
-if [ "$MODE" = "direct" ]; then
+if [[ "$MODE" = "direct" ]]; then
   restore_direct
 else
   restore_compose

--- a/app/scripts/setup-dev.sh
+++ b/app/scripts/setup-dev.sh
@@ -35,7 +35,7 @@ echo "🔧 Initializing Local Development Environment..."
 echo "   -> App Directory detected: ${APP_DIR}"
 
 # 2. Create Secrets Directory
-if [ ! -d "$SECRETS_DIR" ]; then
+if [[ ! -d "$SECRETS_DIR" ]]; then
     echo "   -> Creating secrets directory: secrets/"
     mkdir -p "$SECRETS_DIR"
 else
@@ -47,7 +47,7 @@ random_hex() {
     local bytes=$1
     if command -v openssl >/dev/null 2>&1; then
         openssl rand -hex "$bytes"
-    elif [ -r /dev/urandom ]; then
+    elif [[ -r /dev/urandom ]]; then
         head -c "$bytes" /dev/urandom | od -An -tx1 | tr -d ' \n'
     else
         date +%s%N
@@ -59,7 +59,7 @@ generate_secret() {
     local bytes=${2:-32}
     local filepath="${SECRETS_DIR}/${filename}"
 
-    if [ ! -f "$filepath" ]; then
+    if [[ ! -f "$filepath" ]]; then
         echo "   -> Generating secret: ${filename}"
         printf "%s" "$(random_hex "$bytes")" > "$filepath"
     else
@@ -74,7 +74,7 @@ generate_secret "jwt_secret.txt" 32
 generate_secret "data_encryption_key.txt" 32
 
 # 4. Generate .env File
-if [ ! -f "$ENV_FILE" ]; then
+if [[ ! -f "$ENV_FILE" ]]; then
     echo "   -> Creating default .env file..."
     cat <<EOF > "$ENV_FILE"
 # Local Development Environment Variables

--- a/app/scripts/test-db-compose.sh
+++ b/app/scripts/test-db-compose.sh
@@ -11,14 +11,14 @@ ACTION="${1:-up}"
 generate_secret() {
   if command -v openssl >/dev/null 2>&1; then
     openssl rand -hex 16
-  elif [ -r /dev/urandom ]; then
+  elif [[ -r /dev/urandom ]]; then
     head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n'
   else
     date +%s%N
   fi
 }
 
-if [ -z "${TEST_DB_PASS:-}" ]; then
+if [[ -z "${TEST_DB_PASS:-}" ]]; then
   export TEST_DB_PASS
   TEST_DB_PASS="$(generate_secret)"
 fi

--- a/app/scripts/test-db.sh
+++ b/app/scripts/test-db.sh
@@ -19,14 +19,14 @@ TEST_DB_NAME="${TEST_DB_NAME:-prescriptions_test}"
 generate_secret() {
   if command -v openssl >/dev/null 2>&1; then
     openssl rand -hex 16
-  elif [ -r /dev/urandom ]; then
+  elif [[ -r /dev/urandom ]]; then
     head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n'
   else
     date +%s%N
   fi
 }
 
-if [ -z "${TEST_DB_PASS:-}" ]; then
+if [[ -z "${TEST_DB_PASS:-}" ]]; then
   TEST_DB_PASS="$(generate_secret)"
 fi
 
@@ -56,7 +56,7 @@ for _ in $(seq 1 30); do
   sleep 1
 done
 
-if [ "$READY" -ne 1 ]; then
+if [[ "$READY" -ne 1 ]]; then
   echo "Postgres did not become ready in time." >&2
   exit 1
 fi

--- a/app/server/src/api/http/middleware/auth.js
+++ b/app/server/src/api/http/middleware/auth.js
@@ -74,35 +74,21 @@ module.exports = async function auth(req, _res, next) {
   }
 
   const token = header.slice('Bearer '.length).trim();
-  const decoded = tokenService.decode(token);
-  const decodedAudience = decoded?.aud;
-  const audienceMatches = Array.isArray(decodedAudience)
-    ? decodedAudience.includes(oidcConfig.audience)
-    : decodedAudience === oidcConfig.audience;
-  const isOidcToken = Boolean(
-    oidcConfig.enabled &&
-      decoded?.iss &&
-      oidcConfig.issuer &&
-      decoded.iss === oidcConfig.issuer &&
-      audienceMatches
-  );
 
-  if (oidcConfig.required && !isOidcToken) {
-    return next(new AppError({ status: 401, code: 'OIDC_REQUIRED', message: 'Unauthorized' }));
-  }
-
-  if (isOidcToken) {
+  if (oidcConfig.enabled) {
     try {
-    const payload = await oidcTokenService.verify(token);
+      const payload = await oidcTokenService.verify(token);
       const user = await resolveOidcUser(payload);
       enforceOidcMfaClaims(user, payload);
       req.user = user;
       return next();
     } catch (err) {
-      if (err instanceof AppError) {
+      if (oidcConfig.required) {
+        return next(new AppError({ status: 401, code: 'OIDC_REQUIRED', message: 'Unauthorized' }));
+      }
+      if (err instanceof AppError && err.code !== 'INVALID_TOKEN') {
         return next(err);
       }
-      return next(new AppError({ status: 401, code: 'INVALID_TOKEN', message: 'Invalid token' }));
     }
   }
 

--- a/app/server/src/app/server.js
+++ b/app/server/src/app/server.js
@@ -1,4 +1,3 @@
-const http = require('http');
 const https = require('https');
 const fs = require('fs');
 const createApp = require('./createApp');
@@ -7,24 +6,22 @@ const logger = require('../observability/logger');
 const db = require('../infra/db/knex');
 
 const app = createApp();
-let server;
 
-if (env.TLS_CERT_PATH && env.TLS_KEY_PATH) {
-  const tlsOptions = {
-    // eslint-disable-next-line security/detect-non-literal-fs-filename
-    cert: fs.readFileSync(env.TLS_CERT_PATH),
-    // eslint-disable-next-line security/detect-non-literal-fs-filename
-    key: fs.readFileSync(env.TLS_KEY_PATH),
-    minVersion: 'TLSv1.2',
-  };
-  server = https.createServer(tlsOptions, app);
-  logger.info({ tls: true }, 'TLS enabled for API server');
-} else {
-  if (env.ENFORCE_TLS) {
-    logger.error('ENFORCE_TLS is enabled but TLS_CERT_PATH/TLS_KEY_PATH are not set.');
-  }
-  server = http.createServer(app);
+if (!env.TLS_CERT_PATH || !env.TLS_KEY_PATH) {
+  logger.error('TLS_CERT_PATH and TLS_KEY_PATH must be set. Refusing to start without HTTPS.');
+  process.exit(1);
 }
+
+const tlsOptions = {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  cert: fs.readFileSync(env.TLS_CERT_PATH),
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  key: fs.readFileSync(env.TLS_KEY_PATH),
+  minVersion: 'TLSv1.2',
+};
+
+const server = https.createServer(tlsOptions, app);
+logger.info({ tls: true }, 'TLS enabled for API server');
 
 server.listen(env.PORT, '0.0.0.0', () => {
   logger.info({ port: env.PORT, env: env.NODE_ENV }, 'Server started');

--- a/app/server/src/infra/auth/jwtToken.service.js
+++ b/app/server/src/infra/auth/jwtToken.service.js
@@ -28,9 +28,6 @@ class JwtTokenService {
     });
   }
 
-  decode(token) {
-    return jwt.decode(token);
-  }
 }
 
 module.exports = new JwtTokenService();

--- a/app/server/src/infra/db/migrations/20260203_phase2_tables.js
+++ b/app/server/src/infra/db/migrations/20260203_phase2_tables.js
@@ -20,6 +20,137 @@ const toDateOrNull = (value) => {
   return Number.isNaN(parsed.getTime()) ? null : parsed;
 };
 
+const migrateLegacyPrescriptions = async (knex) => {
+  const legacyTableExists = await knex.schema.hasTable('prescriptions');
+  if (!legacyTableExists) return;
+
+  const legacyRows = await knex('prescriptions').select(
+    'id',
+    'clinic_name',
+    'date',
+    'doctor',
+    'patient',
+    'medications'
+  );
+
+  if (!legacyRows.length) return;
+
+  const v2 = knex.withSchema(SCHEMA);
+  const medicationCache = new Map();
+
+  for (const row of legacyRows) {
+    const doctor = row.doctor || {};
+    const patient = row.patient || {};
+
+    const doctorEmail = doctor.email || `legacy-${randomUUID()}@example.com`;
+    const patientEmail = patient.email || `legacy-${randomUUID()}@example.com`;
+    const doctorLicense = doctor.license || `legacy-${randomUUID()}`;
+    const legacyPasswordHash = await bcrypt.hash(randomUUID(), 10);
+
+    let doctorUser = await v2('users').where({ email: doctorEmail }).first();
+    if (!doctorUser) {
+      const doctorUserId = randomUUID();
+      await v2('users').insert({
+        id: doctorUserId,
+        email: doctorEmail,
+        password_hash: legacyPasswordHash,
+        role: 'doctor',
+        mfa_enabled: false,
+      });
+      doctorUser = { id: doctorUserId };
+    }
+
+    let patientUser = await v2('users').where({ email: patientEmail }).first();
+    if (!patientUser) {
+      const patientUserId = randomUUID();
+      await v2('users').insert({
+        id: patientUserId,
+        email: patientEmail,
+        password_hash: legacyPasswordHash,
+        role: 'patient',
+        mfa_enabled: false,
+      });
+      patientUser = { id: patientUserId };
+    }
+
+    let doctorRecord = await v2('doctors').where({ license_number: doctorLicense }).first();
+    if (!doctorRecord) {
+      const doctorId = randomUUID();
+      const doctorName = splitName(doctor.name);
+      await v2('doctors').insert({
+        id: doctorId,
+        user_id: doctorUser.id,
+        first_name: doctorName.firstName,
+        last_name: doctorName.lastName,
+        license_number: doctorLicense,
+        phone: doctor.phone || null,
+        email: doctorEmail,
+      });
+      doctorRecord = { id: doctorId };
+    }
+
+    let patientRecord = await v2('patients').where({ user_id: patientUser.id }).first();
+    if (!patientRecord) {
+      const patientId = randomUUID();
+      const patientName = splitName(patient.name);
+      await v2('patients').insert({
+        id: patientId,
+        user_id: patientUser.id,
+        first_name: patientName.firstName,
+        last_name: patientName.lastName,
+        dob: toDateOrNull(patient.dob),
+        gender: patient.gender || null,
+        phone: patient.phone || null,
+        email: patientEmail,
+      });
+      patientRecord = { id: patientId };
+    }
+
+    const prescriptionId = randomUUID();
+    const issuedAt = toDateOrNull(row.date) || new Date();
+
+    await v2('prescriptions').insert({
+      id: prescriptionId,
+      patient_id: patientRecord.id,
+      doctor_id: doctorRecord.id,
+      status: 'active',
+      issued_at: issuedAt,
+      notes: row.clinic_name || null,
+    });
+
+    const meds = Array.isArray(row.medications) ? row.medications : [];
+    for (const med of meds) {
+      const medName = med.name || 'Unknown';
+      let medicationId = medicationCache.get(medName);
+
+      if (!medicationId) {
+        const existingMed = await v2('medications_catalog').where({ name: medName }).first();
+        if (existingMed) {
+          medicationId = existingMed.id;
+        } else {
+          medicationId = randomUUID();
+          await v2('medications_catalog').insert({
+            id: medicationId,
+            name: medName,
+            strength: med.dosage || null,
+            is_active: true,
+          });
+        }
+        medicationCache.set(medName, medicationId);
+      }
+
+      await v2('prescription_items').insert({
+        id: randomUUID(),
+        prescription_id: prescriptionId,
+        medication_id: medicationId,
+        dose: med.dosage || null,
+        quantity: med.quantity || null,
+        instructions: med.directions || null,
+      });
+    }
+  }
+};
+
 exports.up = async function (knex) {
   await knex.raw(`CREATE SCHEMA IF NOT EXISTS ${SCHEMA}`);
 
@@ -200,134 +331,8 @@ exports.up = async function (knex) {
     table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
   });
 
-  const legacyTableExists = await knex.schema.hasTable('prescriptions');
-  if (!legacyTableExists) return;
+  await migrateLegacyPrescriptions(knex);
 
-  const legacyRows = await knex('prescriptions').select(
-    'id',
-    'clinic_name',
-    'date',
-    'doctor',
-    'patient',
-    'medications'
-  );
-
-  if (!legacyRows.length) return;
-
-  const v2 = knex.withSchema(SCHEMA);
-  const medicationCache = new Map();
-
-  for (const row of legacyRows) {
-    const doctor = row.doctor || {};
-    const patient = row.patient || {};
-
-    const doctorEmail = doctor.email || `legacy-${randomUUID()}@example.com`;
-    const patientEmail = patient.email || `legacy-${randomUUID()}@example.com`;
-    const doctorLicense = doctor.license || `legacy-${randomUUID()}`;
-    const legacyPasswordHash = await bcrypt.hash(randomUUID(), 10);
-
-    let doctorUser = await v2('users').where({ email: doctorEmail }).first();
-    if (!doctorUser) {
-      const doctorUserId = randomUUID();
-      await v2('users').insert({
-        id: doctorUserId,
-        email: doctorEmail,
-        password_hash: legacyPasswordHash,
-        role: 'doctor',
-        mfa_enabled: false,
-      });
-      doctorUser = { id: doctorUserId };
-    }
-
-    let patientUser = await v2('users').where({ email: patientEmail }).first();
-    if (!patientUser) {
-      const patientUserId = randomUUID();
-      await v2('users').insert({
-        id: patientUserId,
-        email: patientEmail,
-        password_hash: legacyPasswordHash,
-        role: 'patient',
-        mfa_enabled: false,
-      });
-      patientUser = { id: patientUserId };
-    }
-
-    let doctorRecord = await v2('doctors').where({ license_number: doctorLicense }).first();
-    if (!doctorRecord) {
-      const doctorId = randomUUID();
-      const doctorName = splitName(doctor.name);
-      await v2('doctors').insert({
-        id: doctorId,
-        user_id: doctorUser.id,
-        first_name: doctorName.firstName,
-        last_name: doctorName.lastName,
-        license_number: doctorLicense,
-        phone: doctor.phone || null,
-        email: doctorEmail,
-      });
-      doctorRecord = { id: doctorId };
-    }
-
-    let patientRecord = await v2('patients').where({ user_id: patientUser.id }).first();
-    if (!patientRecord) {
-      const patientId = randomUUID();
-      const patientName = splitName(patient.name);
-      await v2('patients').insert({
-        id: patientId,
-        user_id: patientUser.id,
-        first_name: patientName.firstName,
-        last_name: patientName.lastName,
-        dob: toDateOrNull(patient.dob),
-        gender: patient.gender || null,
-        phone: patient.phone || null,
-        email: patientEmail,
-      });
-      patientRecord = { id: patientId };
-    }
-
-    const prescriptionId = randomUUID();
-    const issuedAt = toDateOrNull(row.date) || new Date();
-
-    await v2('prescriptions').insert({
-      id: prescriptionId,
-      patient_id: patientRecord.id,
-      doctor_id: doctorRecord.id,
-      status: 'active',
-      issued_at: issuedAt,
-      notes: row.clinic_name || null,
-    });
-
-    const meds = Array.isArray(row.medications) ? row.medications : [];
-    for (const med of meds) {
-      const medName = med.name || 'Unknown';
-      let medicationId = medicationCache.get(medName);
-
-      if (!medicationId) {
-        const existingMed = await v2('medications_catalog').where({ name: medName }).first();
-        if (existingMed) {
-          medicationId = existingMed.id;
-        } else {
-          medicationId = randomUUID();
-          await v2('medications_catalog').insert({
-            id: medicationId,
-            name: medName,
-            strength: med.dosage || null,
-            is_active: true,
-          });
-        }
-        medicationCache.set(medName, medicationId);
-      }
-
-      await v2('prescription_items').insert({
-        id: randomUUID(),
-        prescription_id: prescriptionId,
-        medication_id: medicationId,
-        dose: med.dosage || null,
-        quantity: med.quantity || null,
-        instructions: med.directions || null,
-      });
-    }
-  }
 };
 
 exports.down = async function (knex) {

--- a/app/server/tests/unit/api.v2.coverage.test.js
+++ b/app/server/tests/unit/api.v2.coverage.test.js
@@ -1,0 +1,212 @@
+const validUuid = '123e4567-e89b-42d3-a456-426614174000';
+
+describe('Unit: api/v2 coverage', () => {
+  describe('audit.helpers', () => {
+    afterEach(() => {
+      jest.resetModules();
+      jest.clearAllMocks();
+      jest.dontMock('../../src/observability/logger');
+      jest.dontMock('../../src/config/audit');
+    });
+
+    it('buildAuditContext maps request metadata safely', () => {
+      const { buildAuditContext } = require('../../src/api/v2/audit/audit.helpers');
+      const req = {
+        user: { sub: 'user-1' },
+        ip: '127.0.0.1',
+        id: 'req-1',
+        get: jest.fn((name) => (name === 'user-agent' ? 'jest-agent' : null)),
+      };
+
+      expect(buildAuditContext(req)).toEqual({
+        actorUserId: 'user-1',
+        ipAddress: '127.0.0.1',
+        userAgent: 'jest-agent',
+        metadata: { requestId: 'req-1' },
+      });
+    });
+
+    it('sanitizeMetadata redacts sensitive keys and strict-mode objects', () => {
+      const { sanitizeMetadata } = require('../../src/api/v2/audit/audit.helpers');
+      const input = {
+        refreshToken: 'x',
+        password: 'secret',
+        safe: 'value',
+        nested: { secret: true },
+      };
+
+      expect(sanitizeMetadata(input, 'none')).toEqual({
+        refreshToken: '[REDACTED]',
+        password: '[REDACTED]',
+        safe: 'value',
+        nested: { secret: true },
+      });
+
+      expect(sanitizeMetadata(input, 'strict')).toEqual({
+        refreshToken: '[REDACTED]',
+        password: '[REDACTED]',
+        safe: 'value',
+        nested: '[REDACTED]',
+      });
+    });
+
+    it('safeAudit applies default redaction mode and logs sanitized payload', async () => {
+      const warn = jest.fn();
+      jest.doMock('../../src/observability/logger', () => ({ warn }));
+      jest.doMock('../../src/config/audit', () => ({ piiRedaction: 'strict' }));
+
+      let safeAudit;
+      jest.isolateModules(() => {
+        ({ safeAudit } = require('../../src/api/v2/audit/audit.helpers'));
+      });
+
+      const logEvent = jest.fn().mockResolvedValue(undefined);
+      await safeAudit({ logEvent }, { eventType: 'x', metadata: { token: 'abc', nested: { a: 1 } } });
+
+      expect(logEvent).toHaveBeenCalledWith({
+        eventType: 'x',
+        redactionMode: 'strict',
+        metadata: { token: '[REDACTED]', nested: '[REDACTED]' },
+      });
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('safeAudit swallows failures and emits warning log', async () => {
+      const warn = jest.fn();
+      jest.doMock('../../src/observability/logger', () => ({ warn }));
+
+      let safeAudit;
+      jest.isolateModules(() => {
+        ({ safeAudit } = require('../../src/api/v2/audit/audit.helpers'));
+      });
+
+      const failure = new Error('audit failed');
+      const logEvent = jest.fn().mockRejectedValue(failure);
+
+      await expect(safeAudit({ logEvent }, { eventType: 'x', metadata: {} })).resolves.toBeUndefined();
+      expect(warn).toHaveBeenCalledWith({ err: failure }, 'Audit log failed');
+    });
+  });
+
+  describe('v2 request schemas', () => {
+    it('auth login schema normalizes email and rejects weak password', () => {
+      const { loginSchema } = require('../../src/api/v2/auth/auth.schemas');
+
+      const valid = loginSchema.validate({ email: '  USER@EXAMPLE.COM ', password: 'StrongPass123' });
+      expect(valid.error).toBeUndefined();
+      expect(valid.value.email).toBe('user@example.com');
+
+      const invalid = loginSchema.validate({ email: 'user@example.com', password: 'short' });
+      expect(invalid.error).toBeDefined();
+    });
+
+    it('patients search schema enforces filter presence', () => {
+      const { searchSchema } = require('../../src/api/v2/patients/patients.schemas');
+
+      expect(searchSchema.validate({}).error).toBeDefined();
+      expect(searchSchema.validate({ name: 'Ana' }).error).toBeUndefined();
+    });
+
+    it('prescriptions schemas enforce required ids/items and update min payload', () => {
+      const {
+        createPrescriptionSchema,
+        updatePrescriptionSchema,
+      } = require('../../src/api/v2/prescriptions/prescriptions.schemas');
+
+      expect(
+        createPrescriptionSchema.validate({
+          patientId: validUuid,
+          items: [{ medicationId: validUuid, dose: '1x', instructions: 'after meal' }],
+        }).error
+      ).toBeUndefined();
+
+      expect(createPrescriptionSchema.validate({ patientId: validUuid, items: [] }).error).toBeDefined();
+      expect(updatePrescriptionSchema.validate({}).error).toBeDefined();
+      expect(updatePrescriptionSchema.validate({ status: 'completed' }).error).toBeUndefined();
+    });
+
+    it('encounters and medications schemas validate status/query constraints', () => {
+      const { updateEncounterSchema } = require('../../src/api/v2/encounters/encounters.schemas');
+      const { medicationsSearchSchema } = require('../../src/api/v2/medications/medications.schemas');
+
+      expect(updateEncounterSchema.validate({ status: 'open' }).error).toBeUndefined();
+      expect(updateEncounterSchema.validate({ status: 'invalid' }).error).toBeDefined();
+
+      expect(medicationsSearchSchema.validate({ query: 'am', limit: 10 }).error).toBeUndefined();
+      expect(medicationsSearchSchema.validate({ query: 'a' }).error).toBeDefined();
+    });
+  });
+  describe('v2 controllers', () => {
+    afterEach(() => {
+      jest.resetModules();
+      jest.clearAllMocks();
+      jest.dontMock('../../src/core/v2/doctors.service');
+      jest.dontMock('../../src/infra/v2/doctors.repository');
+      jest.dontMock('../../src/core/v2/medications.service');
+      jest.dontMock('../../src/infra/v2/medications.repository');
+    });
+
+    it('doctors controller returns getMe payload and forwards failures', async () => {
+      const getMe = jest.fn().mockResolvedValue({ id: 'doc-1' });
+      const getById = jest.fn().mockResolvedValue({ id: 'doc-2' });
+
+      jest.doMock('../../src/core/v2/doctors.service', () => ({
+        DoctorsService: jest.fn().mockImplementation(() => ({ getMe, getById })),
+      }));
+      jest.doMock('../../src/infra/v2/doctors.repository', () => ({
+        DoctorsRepository: jest.fn().mockImplementation(() => ({})),
+      }));
+
+      let controller;
+      jest.isolateModules(() => {
+        controller = require('../../src/api/v2/doctors/doctors.controller');
+      });
+
+      const req = { user: { sub: 'user-1' }, params: { id: 'doc-2' } };
+      const res = { json: jest.fn().mockReturnValue('json-ok') };
+      const next = jest.fn();
+
+      await expect(controller.getMe(req, res, next)).resolves.toBe('json-ok');
+      expect(getMe).toHaveBeenCalledWith('user-1');
+      expect(res.json).toHaveBeenCalledWith({ id: 'doc-1' });
+
+      await expect(controller.getById(req, res, next)).resolves.toBe('json-ok');
+      expect(getById).toHaveBeenCalledWith({ doctorId: 'doc-2', requester: req.user });
+
+      const err = new Error('boom');
+      getMe.mockRejectedValueOnce(err);
+      await controller.getMe(req, res, next);
+      expect(next).toHaveBeenCalledWith(err);
+    });
+
+    it('medications controller wraps search response and forwards errors', async () => {
+      const search = jest.fn().mockResolvedValue([{ id: 'med-1' }]);
+
+      jest.doMock('../../src/core/v2/medications.service', () => ({
+        MedicationsService: jest.fn().mockImplementation(() => ({ search })),
+      }));
+      jest.doMock('../../src/infra/v2/medications.repository', () => ({
+        MedicationsRepository: jest.fn().mockImplementation(() => ({})),
+      }));
+
+      let controller;
+      jest.isolateModules(() => {
+        controller = require('../../src/api/v2/medications/medications.controller');
+      });
+
+      const req = { query: { query: 'amox', limit: 5 } };
+      const res = { json: jest.fn().mockReturnValue('json-ok') };
+      const next = jest.fn();
+
+      await expect(controller.search(req, res, next)).resolves.toBe('json-ok');
+      expect(search).toHaveBeenCalledWith('amox', 5);
+      expect(res.json).toHaveBeenCalledWith({ results: [{ id: 'med-1' }] });
+
+      const err = new Error('search failed');
+      search.mockRejectedValueOnce(err);
+      await controller.search(req, res, next);
+      expect(next).toHaveBeenCalledWith(err);
+    });
+  });
+
+});

--- a/app/server/tests/unit/auth.v2.controller.test.js
+++ b/app/server/tests/unit/auth.v2.controller.test.js
@@ -1,0 +1,195 @@
+const { buildTestId, buildTestEmail } = require('../helpers/testCredentials');
+
+const loadController = ({
+  loginResult,
+  loginError,
+  issueResult = { refreshToken: 'refresh-1' },
+  revokeResult = { revoked: true, userId: 'user-1' },
+  findByIdResult = { id: 'user-1', mfa_secret: 'abc', mfa_enabled: true },
+  verifyResult = { verified: true },
+  enrollResult = { secret: 'ABC', qrCodeDataUrl: 'data:image/png;base64,x' },
+} = {}) => {
+  jest.resetModules();
+
+  const login = loginError ? jest.fn().mockRejectedValue(loginError) : jest.fn().mockResolvedValue(loginResult);
+  const issue = jest.fn().mockResolvedValue(issueResult);
+  const rotate = jest.fn();
+  const revoke = jest.fn().mockResolvedValue(revokeResult);
+  const revokeAll = jest.fn().mockResolvedValue({ revoked: true });
+  const verify = jest.fn().mockResolvedValue(verifyResult);
+  const enroll = jest.fn().mockResolvedValue(enrollResult);
+  const findById = jest.fn().mockResolvedValue(findByIdResult);
+  const setMfaEnabled = jest.fn().mockResolvedValue(1);
+  const setMfaSecret = jest.fn().mockResolvedValue(1);
+  const sign = jest.fn().mockReturnValue('access-token');
+  const signWithOptions = jest.fn().mockReturnValue('mfa-token');
+  const safeAudit = jest.fn().mockResolvedValue(undefined);
+  const buildAuditContext = jest.fn().mockReturnValue({ metadata: { requestId: 'req-1' }, ipAddress: '127.0.0.1' });
+
+  jest.doMock('../../src/core/auth/passwordAuth.service', () => ({
+    PasswordAuthService: jest.fn().mockImplementation(() => ({ login })),
+  }));
+  jest.doMock('../../src/core/auth/refreshToken.service', () => ({
+    RefreshTokenService: jest.fn().mockImplementation(() => ({ issue, rotate, revoke, revokeAll })),
+  }));
+  jest.doMock('../../src/core/auth/mfa.service', () => ({
+    MfaService: jest.fn().mockImplementation(() => ({ verify, enroll })),
+  }));
+  jest.doMock('../../src/infra/users/users.repository', () => ({
+    UsersRepository: jest.fn().mockImplementation(() => ({ findById, setMfaEnabled, setMfaSecret })),
+  }));
+  jest.doMock('../../src/infra/auth/jwtToken.service', () => ({ sign, signWithOptions }));
+  jest.doMock('../../src/api/v2/audit/audit.helpers', () => ({ buildAuditContext, safeAudit }));
+  jest.doMock('../../src/config/env', () => ({
+    LOGIN_MAX_FAILURES: 5,
+    LOGIN_LOCK_MINUTES: 15,
+    LOGIN_FAILURE_WINDOW_MINUTES: 15,
+    REFRESH_TOKEN_TTL_DAYS: 7,
+    MFA_TOKEN_TTL_MINUTES: 5,
+    JWT_ISSUER: 'stayhealthy',
+  }));
+  jest.doMock('../../src/config/audit', () => ({ sink: 'console', piiRedaction: 'none' }));
+  jest.doMock('../../src/core/auth/loginLockout', () => ({ LoginLockout: jest.fn().mockImplementation(() => ({})) }));
+  jest.doMock('../../src/core/v2/audit.service', () => ({ AuditService: jest.fn().mockImplementation(() => ({})) }));
+  jest.doMock('../../src/infra/v2/audit.repository', () => ({ AuditRepository: jest.fn().mockImplementation(() => ({})) }));
+  jest.doMock('../../src/infra/v2/audit.console.repository', () => ({ AuditConsoleRepository: jest.fn().mockImplementation(() => ({})) }));
+  jest.doMock('../../src/infra/v2/refreshTokens.repository', () => ({ RefreshTokensRepository: jest.fn().mockImplementation(() => ({})) }));
+
+  let controller;
+  jest.isolateModules(() => {
+    controller = require('../../src/api/v2/auth/auth.controller');
+  });
+
+  return {
+    controller,
+    mocks: {
+      login,
+      issue,
+      revoke,
+      verify,
+      enroll,
+      findById,
+      setMfaEnabled,
+      setMfaSecret,
+      sign,
+      signWithOptions,
+      safeAudit,
+      buildAuditContext,
+    },
+  };
+};
+
+describe('Unit: api/v2/auth.controller', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('login returns MFA challenge when user requires MFA', async () => {
+    const userId = buildTestId();
+    const email = buildTestEmail('doctor');
+    const { controller, mocks } = loadController({
+      loginResult: { user: { id: userId, email, role: 'doctor', mfaEnabled: true } },
+    });
+
+    const req = { body: { email, password: 'secret' } };
+    const json = jest.fn();
+    const res = { status: jest.fn(() => ({ json })) };
+    const next = jest.fn();
+
+    await controller.login(req, res, next);
+
+    expect(mocks.signWithOptions).toHaveBeenCalledWith(
+      expect.objectContaining({ sub: userId, mfa: true }),
+      { expiresIn: '5m' }
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith({
+      mfaRequired: true,
+      mfaToken: 'mfa-token',
+      user: { id: userId, email, role: 'doctor', mfaEnabled: true },
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('login issues refresh token when MFA is not required', async () => {
+    const userId = buildTestId();
+    const email = buildTestEmail('patient');
+    const { controller, mocks } = loadController({
+      loginResult: {
+        accessToken: 'access-1',
+        tokenType: 'Bearer',
+        user: { id: userId, email, role: 'patient', mfaEnabled: false },
+      },
+      issueResult: { refreshToken: 'refresh-xyz' },
+    });
+
+    const req = { body: { email, password: 'secret' } };
+    const json = jest.fn();
+    const res = { status: jest.fn(() => ({ json })) };
+
+    await controller.login(req, res, jest.fn());
+
+    expect(mocks.issue).toHaveBeenCalledWith(userId);
+    expect(json).toHaveBeenCalledWith({
+      accessToken: 'access-1',
+      tokenType: 'Bearer',
+      user: { id: userId, email, role: 'patient', mfaEnabled: false },
+      refreshToken: 'refresh-xyz',
+    });
+  });
+
+  it('login audits invalid credentials failures and forwards error', async () => {
+    const error = { code: 'INVALID_CREDENTIALS' };
+    const { controller, mocks } = loadController({ loginError: error });
+
+    const req = { body: { email: buildTestEmail('bad') } };
+    const next = jest.fn();
+
+    await controller.login(req, { status: jest.fn() }, next);
+
+    expect(mocks.safeAudit).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ eventType: 'login_failed', subjectType: 'user' })
+    );
+    expect(next).toHaveBeenCalledWith(error);
+  });
+
+  it('revoke returns revoked=true and emits revoke audit event', async () => {
+    const { controller, mocks } = loadController({ revokeResult: { revoked: true, userId: 'user-1' } });
+    const req = { body: { refreshToken: 'refresh-1' }, user: { sub: 'user-1' } };
+    const json = jest.fn();
+    const res = { status: jest.fn(() => ({ json })) };
+
+    await controller.revoke(req, res, jest.fn());
+
+    expect(mocks.revoke).toHaveBeenCalledWith('refresh-1');
+    expect(mocks.safeAudit).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ eventType: 'refresh_token_revoked', subjectId: 'user-1' })
+    );
+    expect(json).toHaveBeenCalledWith({ revoked: true });
+  });
+
+  it('mfaStatus returns unauthorized when user is missing', async () => {
+    const { controller } = loadController({ findByIdResult: null });
+    const next = jest.fn();
+
+    await controller.mfaStatus({ user: { sub: 'missing' } }, { status: jest.fn() }, next);
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ code: 'UNAUTHORIZED', status: 401 }));
+  });
+
+  it('verifyMfa returns token payload and audits success', async () => {
+    const { controller, mocks } = loadController({ verifyResult: { verified: true } });
+    const req = { user: { sub: 'user-1', email: 'p@example.test', role: 'patient' }, body: { code: '123456' } };
+    const json = jest.fn();
+    const res = { status: jest.fn(() => ({ json })) };
+
+    await controller.verifyMfa(req, res, jest.fn());
+
+    expect(mocks.verify).toHaveBeenCalledWith({ userId: 'user-1', code: '123456' });
+    expect(mocks.sign).toHaveBeenCalledWith(expect.objectContaining({ sub: 'user-1', mfaEnabled: true }));
+    expect(mocks.safeAudit).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({ eventType: 'mfa_verified' }));
+    expect(json).toHaveBeenCalledWith(expect.objectContaining({ accessToken: 'access-token', refreshToken: 'refresh-1', tokenType: 'Bearer' }));
+  });
+});

--- a/app/server/tests/unit/core.v2.services.test.js
+++ b/app/server/tests/unit/core.v2.services.test.js
@@ -1,0 +1,205 @@
+const { DoctorsService } = require('../../src/core/v2/doctors.service');
+const { DoctorContextService } = require('../../src/core/v2/doctorContext.service');
+const { EncountersService } = require('../../src/core/v2/encounters.service');
+
+describe('Unit: core/v2 services', () => {
+  describe('DoctorContextService', () => {
+    it('returns doctor for known user id', async () => {
+      const doctorsRepository = { findByUserId: jest.fn().mockResolvedValue({ id: 'doc-1' }) };
+      const encountersRepository = { existsForDoctorPatient: jest.fn() };
+      const service = new DoctorContextService({ doctorsRepository, encountersRepository });
+
+      await expect(service.getDoctorByUserId('user-1')).resolves.toEqual({ id: 'doc-1' });
+      expect(doctorsRepository.findByUserId).toHaveBeenCalledWith('user-1');
+    });
+
+    it('throws when user is not a doctor', async () => {
+      const doctorsRepository = { findByUserId: jest.fn().mockResolvedValue(null) };
+      const encountersRepository = { existsForDoctorPatient: jest.fn() };
+      const service = new DoctorContextService({ doctorsRepository, encountersRepository });
+
+      await expect(service.getDoctorByUserId('user-1')).rejects.toMatchObject({
+        status: 403,
+        code: 'NOT_AUTHORIZED',
+      });
+    });
+
+    it('enforces patient access checks', async () => {
+      const doctorsRepository = { findByUserId: jest.fn() };
+      const encountersRepository = { existsForDoctorPatient: jest.fn().mockResolvedValue(false) };
+      const service = new DoctorContextService({ doctorsRepository, encountersRepository });
+
+      await expect(service.ensurePatientAccess({ doctorId: 'doc-1', patientId: 'pat-1' })).rejects.toMatchObject({
+        status: 403,
+        code: 'FORBIDDEN',
+      });
+      expect(encountersRepository.existsForDoctorPatient).toHaveBeenCalledWith({
+        doctorId: 'doc-1',
+        patientId: 'pat-1',
+        status: 'open',
+      });
+    });
+  });
+
+  describe('DoctorsService', () => {
+    it('maps getMe response and returns mfa/email fields', async () => {
+      const doctorsRepository = {
+        findByUserId: jest.fn().mockResolvedValue({
+          id: 'doc-1',
+          user_id: 'user-1',
+          first_name: 'Ana',
+          last_name: 'Silva',
+          license_number: 'LIC-1',
+          specialty: 'cardiology',
+          phone: '555-111',
+          user_email: 'ana@example.com',
+          mfa_enabled: true,
+        }),
+      };
+      const service = new DoctorsService({ doctorsRepository });
+
+      await expect(service.getMe('user-1')).resolves.toEqual({
+        id: 'doc-1',
+        userId: 'user-1',
+        firstName: 'Ana',
+        lastName: 'Silva',
+        licenseNumber: 'LIC-1',
+        specialty: 'cardiology',
+        phone: '555-111',
+        email: 'ana@example.com',
+        mfaEnabled: true,
+      });
+    });
+
+    it('blocks getById for non-admin mismatched requester', async () => {
+      const doctorsRepository = {
+        findById: jest.fn().mockResolvedValue({
+          id: 'doc-1',
+          user_id: 'different-user',
+          first_name: 'Ana',
+          last_name: 'Silva',
+          license_number: 'LIC-1',
+        }),
+      };
+      const service = new DoctorsService({ doctorsRepository });
+
+      await expect(
+        service.getById({ doctorId: 'doc-1', requester: { role: 'doctor', sub: 'user-1' } })
+      ).rejects.toMatchObject({ status: 403, code: 'FORBIDDEN' });
+    });
+
+    it('allows admin to fetch doctor profile', async () => {
+      const doctorsRepository = {
+        findById: jest.fn().mockResolvedValue({
+          id: 'doc-1',
+          user_id: 'user-1',
+          first_name: 'Ana',
+          last_name: 'Silva',
+          license_number: 'LIC-1',
+          specialty: null,
+          phone: null,
+          email: 'fallback@example.com',
+          mfa_enabled: false,
+        }),
+      };
+      const service = new DoctorsService({ doctorsRepository });
+
+      await expect(
+        service.getById({ doctorId: 'doc-1', requester: { role: 'admin', sub: 'admin-1' } })
+      ).resolves.toMatchObject({ id: 'doc-1', email: 'fallback@example.com' });
+    });
+  });
+
+  describe('EncountersService', () => {
+    const buildService = () => {
+      const encountersRepository = {
+        findByDoctorPatient: jest.fn(),
+        create: jest.fn(),
+        findById: jest.fn(),
+        update: jest.fn(),
+      };
+      const patientsRepository = { findById: jest.fn() };
+      const doctorContext = {
+        getDoctorByUserId: jest.fn().mockResolvedValue({ id: 'doc-1' }),
+      };
+      const service = new EncountersService({ encountersRepository, patientsRepository, doctorContext });
+      return { service, encountersRepository, patientsRepository, doctorContext };
+    };
+
+    it('creates encounter when patient exists and no open encounter', async () => {
+      const { service, encountersRepository, patientsRepository } = buildService();
+      patientsRepository.findById.mockResolvedValue({ id: 'pat-1' });
+      encountersRepository.findByDoctorPatient.mockResolvedValue(null);
+      encountersRepository.create.mockImplementation(async (payload) => ({
+        ...payload,
+        created_at: new Date('2026-01-01T00:00:00Z'),
+        updated_at: new Date('2026-01-01T00:00:00Z'),
+      }));
+
+      const result = await service.create({ doctorUserId: 'user-1', patientId: 'pat-1', facilityId: 'fac-1' });
+
+      expect(encountersRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          patient_id: 'pat-1',
+          doctor_id: 'doc-1',
+          facility_id: 'fac-1',
+          status: 'open',
+          started_at: expect.any(Date),
+          ended_at: null,
+        })
+      );
+      expect(result).toMatchObject({ patientId: 'pat-1', doctorId: 'doc-1', status: 'open' });
+    });
+
+    it('rejects encounter create when patient is missing', async () => {
+      const { service, patientsRepository } = buildService();
+      patientsRepository.findById.mockResolvedValue(null);
+
+      await expect(service.create({ doctorUserId: 'user-1', patientId: 'pat-1' })).rejects.toMatchObject({
+        status: 404,
+        code: 'NOT_FOUND',
+      });
+    });
+
+    it('sets ended_at when closing and clears it when reopening', async () => {
+      const { service, encountersRepository } = buildService();
+      encountersRepository.findById
+        .mockResolvedValueOnce({ id: 'enc-1', doctor_id: 'doc-1', started_at: new Date('2026-01-01T00:00:00Z') })
+        .mockResolvedValueOnce({ id: 'enc-1', doctor_id: 'doc-1', started_at: null });
+
+      encountersRepository.update
+        .mockResolvedValueOnce({
+          id: 'enc-1',
+          patient_id: 'pat-1',
+          doctor_id: 'doc-1',
+          facility_id: null,
+          status: 'closed',
+          started_at: new Date('2026-01-01T00:00:00Z'),
+          ended_at: new Date('2026-01-02T00:00:00Z'),
+        })
+        .mockResolvedValueOnce({
+          id: 'enc-1',
+          patient_id: 'pat-1',
+          doctor_id: 'doc-1',
+          facility_id: null,
+          status: 'open',
+          started_at: new Date('2026-01-03T00:00:00Z'),
+          ended_at: null,
+        });
+
+      await service.updateStatus({ doctorUserId: 'user-1', encounterId: 'enc-1', status: 'closed' });
+      await service.updateStatus({ doctorUserId: 'user-1', encounterId: 'enc-1', status: 'open' });
+
+      expect(encountersRepository.update).toHaveBeenNthCalledWith(
+        1,
+        'enc-1',
+        expect.objectContaining({ status: 'closed', ended_at: expect.any(Date) })
+      );
+      expect(encountersRepository.update).toHaveBeenNthCalledWith(
+        2,
+        'enc-1',
+        expect.objectContaining({ status: 'open', ended_at: null, started_at: expect.any(Date) })
+      );
+    });
+  });
+});

--- a/app/server/tests/unit/infra.repositories.test.js
+++ b/app/server/tests/unit/infra.repositories.test.js
@@ -1,0 +1,165 @@
+const { buildTestId } = require('../helpers/testCredentials');
+
+describe('Unit: infra repositories', () => {
+  describe('UsersRepository', () => {
+    const buildDb = () => {
+      const first = jest.fn();
+      const update = jest.fn();
+      const where = jest.fn(() => ({ first, update }));
+      const from = jest.fn(() => ({ where }));
+      const withSchema = jest.fn(() => ({ from }));
+      return { db: { withSchema }, withSchema, from, where, first, update };
+    };
+
+    it('returns null for empty lookup args', async () => {
+      const { UsersRepository } = require('../../src/infra/users/users.repository');
+      const { db, withSchema } = buildDb();
+      const repo = new UsersRepository(db);
+
+      await expect(repo.findByEmail('')).resolves.toBeNull();
+      await expect(repo.findById('')).resolves.toBeNull();
+      expect(withSchema).not.toHaveBeenCalled();
+    });
+
+    it('queries users by email/id and updates MFA fields', async () => {
+      const { UsersRepository } = require('../../src/infra/users/users.repository');
+      const { db, withSchema, from, where, first, update } = buildDb();
+      const repo = new UsersRepository(db);
+      const userId = buildTestId();
+      const email = 'doctor@example.com';
+
+      first
+        .mockResolvedValueOnce({ id: userId, email })
+        .mockResolvedValueOnce({ id: userId, email });
+      update.mockResolvedValue(1);
+
+      await expect(repo.findByEmail(email)).resolves.toEqual({ id: userId, email });
+      await expect(repo.findById(userId)).resolves.toEqual({ id: userId, email });
+      await expect(repo.setMfaEnabled(userId, true)).resolves.toBe(1);
+      await expect(repo.setMfaSecret(userId, 'secret')).resolves.toBe(1);
+
+      expect(withSchema).toHaveBeenCalledWith('v2');
+      expect(from).toHaveBeenCalledWith('users');
+      expect(where).toHaveBeenNthCalledWith(1, { email });
+      expect(where).toHaveBeenNthCalledWith(2, { id: userId });
+      expect(where).toHaveBeenNthCalledWith(3, { id: userId });
+      expect(where).toHaveBeenNthCalledWith(4, { id: userId });
+      expect(update).toHaveBeenNthCalledWith(1, { mfa_enabled: true });
+      expect(update).toHaveBeenNthCalledWith(2, { mfa_secret: 'secret' });
+    });
+  });
+
+  describe('PrescriptionsRepository', () => {
+    afterEach(() => {
+      jest.resetModules();
+      jest.clearAllMocks();
+      jest.dontMock('../../src/infra/db/knex');
+      jest.dontMock('../../src/config/env');
+    });
+
+    it('returns fixture data in test mode', async () => {
+      jest.doMock('../../src/config/env', () => ({ NODE_ENV: 'test' }));
+      jest.doMock('../../src/infra/db/knex', () => jest.fn());
+
+      let PrescriptionsRepository;
+      jest.isolateModules(() => {
+        ({ PrescriptionsRepository } = require('../../src/infra/prescriptions/prescriptions.repository'));
+      });
+
+      const repo = new PrescriptionsRepository();
+      await expect(repo.findById('demo-id')).resolves.toMatchObject({ id: 'demo-id', clinicName: 'StayHealthy' });
+      await expect(repo.findById('missing')).resolves.toBeNull();
+    });
+
+    it('maps database shape outside test mode', async () => {
+      const first = jest.fn().mockResolvedValue({
+        id: 'rx-1',
+        clinic_name: 'Clinic',
+        date: '2024-01-01',
+        doctor: { name: 'Dr A' },
+        patient: { name: 'P B' },
+        medications: [{ name: 'Med' }],
+      });
+      const where = jest.fn(() => ({ first }));
+      const dbMock = jest.fn(() => ({ where }));
+
+      jest.doMock('../../src/config/env', () => ({ NODE_ENV: 'production' }));
+      jest.doMock('../../src/infra/db/knex', () => dbMock);
+
+      let PrescriptionsRepository;
+      jest.isolateModules(() => {
+        ({ PrescriptionsRepository } = require('../../src/infra/prescriptions/prescriptions.repository'));
+      });
+
+      const repo = new PrescriptionsRepository();
+      await expect(repo.findById('rx-1')).resolves.toEqual({
+        id: 'rx-1',
+        clinicName: 'Clinic',
+        date: '2024-01-01',
+        doctor: { name: 'Dr A' },
+        patient: { name: 'P B' },
+        medications: [{ name: 'Med' }],
+      });
+
+      first.mockResolvedValueOnce(null);
+      await expect(repo.findById('missing')).resolves.toBeNull();
+      expect(dbMock).toHaveBeenCalledWith('prescriptions');
+      expect(where).toHaveBeenNthCalledWith(1, { id: 'rx-1' });
+      expect(where).toHaveBeenNthCalledWith(2, { id: 'missing' });
+    });
+  });
+
+  describe('MedicationsRepository', () => {
+    afterEach(() => {
+      jest.resetModules();
+      jest.clearAllMocks();
+      jest.dontMock('../../src/infra/db/knex');
+    });
+
+    it('returns empty list when ids are missing', async () => {
+      const dbMock = { withSchema: jest.fn() };
+      jest.doMock('../../src/infra/db/knex', () => dbMock);
+
+      let MedicationsRepository;
+      jest.isolateModules(() => {
+        ({ MedicationsRepository } = require('../../src/infra/v2/medications.repository'));
+      });
+
+      const repo = new MedicationsRepository();
+      await expect(repo.findByIds()).resolves.toEqual([]);
+      await expect(repo.findByIds([])).resolves.toEqual([]);
+      expect(dbMock.withSchema).not.toHaveBeenCalled();
+    });
+
+    it('queries catalog for id lookups and search', async () => {
+      const select = jest.fn().mockResolvedValue([{ id: 'med-1', name: 'Amoxicillin' }]);
+      const limit = jest.fn(() => ({ select }));
+      const orderBy = jest.fn(() => ({ limit }));
+      const andWhere = jest.fn(() => ({ orderBy }));
+      const whereILike = jest.fn(() => ({ andWhere }));
+      const whereIn = jest.fn(() => ({ select }));
+      const from = jest.fn(() => ({ whereIn, whereILike }));
+      const withSchema = jest.fn(() => ({ from }));
+      const dbMock = { withSchema };
+
+      jest.doMock('../../src/infra/db/knex', () => dbMock);
+
+      let MedicationsRepository;
+      jest.isolateModules(() => {
+        ({ MedicationsRepository } = require('../../src/infra/v2/medications.repository'));
+      });
+
+      const repo = new MedicationsRepository();
+      await expect(repo.findByIds(['med-1'])).resolves.toEqual([{ id: 'med-1', name: 'Amoxicillin' }]);
+      await expect(repo.search('amox', 5)).resolves.toEqual([{ id: 'med-1', name: 'Amoxicillin' }]);
+
+      expect(withSchema).toHaveBeenCalledWith('v2');
+      expect(from).toHaveBeenCalledWith('medications_catalog');
+      expect(whereIn).toHaveBeenCalledWith('id', ['med-1']);
+      expect(whereILike).toHaveBeenCalledWith('name', '%amox%');
+      expect(andWhere).toHaveBeenCalledWith('is_active', true);
+      expect(orderBy).toHaveBeenCalledWith('name');
+      expect(limit).toHaveBeenCalledWith(5);
+    });
+  });
+});

--- a/app/server/tests/unit/infra.v2.auth.repositories.test.js
+++ b/app/server/tests/unit/infra.v2.auth.repositories.test.js
@@ -1,0 +1,167 @@
+const { buildTestId } = require('../helpers/testCredentials');
+
+describe('Unit: infra v2/auth repositories', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    jest.dontMock('../../src/infra/db/knex');
+    jest.dontMock('../../src/infra/auth/jwtToken.service');
+    jest.dontMock('../../src/config/jwt');
+    jest.dontMock('../../src/observability/logger');
+    jest.dontMock('../../src/config/oidc');
+  });
+
+  describe('RefreshTokensRepository', () => {
+    const buildDb = () => {
+      const first = jest.fn().mockResolvedValue({ id: 'rt-1' });
+      const update = jest.fn().mockResolvedValue(1);
+      const whereNull = jest.fn(() => ({ update }));
+      const where = jest.fn(() => ({ first, update, whereNull }));
+      const from = jest.fn(() => ({ where }));
+      const into = jest.fn().mockResolvedValue([1]);
+      const insert = jest.fn(() => ({ into }));
+      const withSchema = jest.fn(() => ({ insert, from }));
+      return { db: { withSchema }, withSchema, insert, into, from, where, whereNull, first, update };
+    };
+
+    it('creates and queries refresh tokens with expected schema calls', async () => {
+      const { RefreshTokensRepository } = require('../../src/infra/v2/refreshTokens.repository');
+      const { db, withSchema, insert, into, from, where, first } = buildDb();
+      const repo = new RefreshTokensRepository(db);
+      const tokenId = buildTestId();
+      const userId = buildTestId();
+
+      await expect(
+        repo.create({ id: tokenId, userId, tokenHash: 'hash-1', expiresAt: '2099-01-01T00:00:00Z' })
+      ).resolves.toEqual([1]);
+      await expect(repo.findByTokenHash('hash-1')).resolves.toEqual({ id: 'rt-1' });
+
+      expect(withSchema).toHaveBeenCalledWith('v2');
+      expect(insert).toHaveBeenCalledWith({
+        id: tokenId,
+        user_id: userId,
+        token_hash: 'hash-1',
+        expires_at: '2099-01-01T00:00:00Z',
+      });
+      expect(into).toHaveBeenCalledWith('refresh_tokens');
+      expect(from).toHaveBeenCalledWith('refresh_tokens');
+      expect(where).toHaveBeenCalledWith({ token_hash: 'hash-1' });
+      expect(first).toHaveBeenCalled();
+    });
+
+    it('returns guard defaults for empty identifiers and revokes tokens', async () => {
+      const { RefreshTokensRepository } = require('../../src/infra/v2/refreshTokens.repository');
+      const { db, where, whereNull, update } = buildDb();
+      const repo = new RefreshTokensRepository(db);
+      const revokedAt = new Date('2026-02-03T00:00:00Z');
+
+      expect(repo.findByTokenHash('')).toBeNull();
+      await expect(repo.revoke('rt-1', revokedAt)).resolves.toBe(1);
+      await expect(repo.revokeByTokenHash('hash-2', revokedAt)).resolves.toBe(1);
+      expect(repo.revokeByTokenHash('', revokedAt)).toBe(0);
+      await expect(repo.revokeAllForUser('user-1', revokedAt)).resolves.toBe(1);
+      expect(repo.revokeAllForUser('', revokedAt)).toBe(0);
+
+      expect(where).toHaveBeenCalledWith({ id: 'rt-1' });
+      expect(where).toHaveBeenCalledWith({ token_hash: 'hash-2' });
+      expect(where).toHaveBeenCalledWith({ user_id: 'user-1' });
+      expect(whereNull).toHaveBeenCalledWith('revoked_at');
+      expect(update).toHaveBeenCalledWith({ revoked_at: revokedAt });
+    });
+  });
+
+  describe('Audit repositories', () => {
+    it('AuditConsoleRepository logs and returns empty list', async () => {
+      const info = jest.fn();
+      jest.doMock('../../src/observability/logger', () => ({ info }));
+
+      let AuditConsoleRepository;
+      jest.isolateModules(() => {
+        ({ AuditConsoleRepository } = require('../../src/infra/v2/audit.console.repository'));
+      });
+
+      const repo = new AuditConsoleRepository();
+      await expect(repo.create({ event_type: 'login' })).resolves.toBeUndefined();
+      await expect(repo.list()).resolves.toEqual([]);
+      expect(info).toHaveBeenCalledWith({ audit: { event_type: 'login' } }, 'AUDIT_EVENT');
+    });
+
+    it('AuditRepository composes list query filters', async () => {
+      const offset = jest.fn(() => query);
+      const limit = jest.fn(() => query);
+      const orderBy = jest.fn(() => query);
+      const select = jest.fn(() => query);
+      const where = jest.fn(() => query);
+      const from = jest.fn(() => query);
+      const query = { select, from, orderBy, limit, offset, where };
+      const withSchema = jest.fn(() => query);
+      jest.doMock('../../src/infra/db/knex', () => ({ withSchema }));
+
+      let AuditRepository;
+      jest.isolateModules(() => {
+        ({ AuditRepository } = require('../../src/infra/v2/audit.repository'));
+      });
+
+      const repo = new AuditRepository();
+      const result = await repo.list({ eventType: 'x', actorUserId: 'u1', subjectType: 'patient', subjectId: 'p1', limit: 10, offset: 2 });
+
+      expect(result).toBe(query);
+      expect(withSchema).toHaveBeenCalledWith('v2');
+      expect(from).toHaveBeenCalledWith('audit_events');
+      expect(orderBy).toHaveBeenCalledWith('created_at', 'desc');
+      expect(limit).toHaveBeenCalledWith(10);
+      expect(offset).toHaveBeenCalledWith(2);
+      expect(where).toHaveBeenCalledWith('event_type', 'x');
+      expect(where).toHaveBeenCalledWith('actor_user_id', 'u1');
+      expect(where).toHaveBeenCalledWith('subject_type', 'patient');
+      expect(where).toHaveBeenCalledWith('subject_id', 'p1');
+    });
+  });
+
+  describe('Auth token services', () => {
+    it('JwtTokenService signs and verifies with configured constraints', () => {
+      const sign = jest.fn(() => 'signed-token');
+      const verify = jest.fn(() => ({ sub: 'u1' }));
+      jest.doMock('jsonwebtoken', () => ({ sign, verify }));
+      jest.doMock('../../src/config/jwt', () => ({
+        secret: 'secret',
+        expiresIn: '15m',
+        issuer: 'issuer',
+        audience: 'aud',
+        algorithms: ['HS256'],
+      }));
+
+      let service;
+      jest.isolateModules(() => {
+        service = require('../../src/infra/auth/jwtToken.service');
+      });
+
+      expect(service.sign({ sub: 'u1' })).toBe('signed-token');
+      expect(service.signWithOptions({ sub: 'u1' }, { expiresIn: '1m' })).toBe('signed-token');
+      expect(service.verify('token-1')).toEqual({ sub: 'u1' });
+
+      expect(sign).toHaveBeenNthCalledWith(1, { sub: 'u1' }, 'secret', expect.objectContaining({ expiresIn: '15m', algorithm: 'HS256' }));
+      expect(sign).toHaveBeenNthCalledWith(2, { sub: 'u1' }, 'secret', expect.objectContaining({ expiresIn: '1m', algorithm: 'HS256' }));
+      expect(verify).toHaveBeenCalledWith('token-1', 'secret', expect.objectContaining({ algorithms: ['HS256'] }));
+    });
+
+    it('OidcTokenService fails closed when issuer/audience are missing', async () => {
+      jest.doMock('../../src/config/oidc', () => ({
+        issuer: '',
+        audience: '',
+        clockToleranceSeconds: 5,
+        jwksUri: '',
+      }));
+
+      let service;
+      jest.isolateModules(() => {
+        service = require('../../src/infra/auth/oidcToken.service');
+      });
+
+      await expect(service.verify('token')).rejects.toMatchObject({
+        status: 500,
+        code: 'OIDC_NOT_CONFIGURED',
+      });
+    });
+  });
+});

--- a/app/server/tests/unit/patients.v2.controller.test.js
+++ b/app/server/tests/unit/patients.v2.controller.test.js
@@ -1,0 +1,169 @@
+const loadController = ({
+  searchResult = [],
+  searchError,
+  patientResult = { id: 'patient-1', firstName: 'A' },
+  patientError,
+  summaryResult = {
+    patient: { id: 'patient-1' },
+    allergies: [{ id: 'allergy-1' }],
+    prescriptions: [{ id: 'rx-1' }, { id: 'rx-2' }],
+  },
+  summaryError,
+  prescriptionsResult = [{ id: 'rx-1' }],
+  prescriptionsError,
+} = {}) => {
+  jest.resetModules();
+
+  const search = searchError ? jest.fn().mockRejectedValue(searchError) : jest.fn().mockResolvedValue(searchResult);
+  const getById = patientError ? jest.fn().mockRejectedValue(patientError) : jest.fn().mockResolvedValue(patientResult);
+  const getSummary = summaryError
+    ? jest.fn().mockRejectedValue(summaryError)
+    : jest.fn().mockResolvedValue(summaryResult);
+  const getPrescriptions = prescriptionsError
+    ? jest.fn().mockRejectedValue(prescriptionsError)
+    : jest.fn().mockResolvedValue(prescriptionsResult);
+
+  const safeAudit = jest.fn().mockResolvedValue(undefined);
+  const buildAuditContext = jest.fn().mockReturnValue({ metadata: { requestId: 'req-1' }, ipAddress: '127.0.0.1' });
+
+  jest.doMock('../../src/core/v2/patients.service', () => ({
+    PatientsService: jest.fn().mockImplementation(() => ({ search, getById, getSummary, getPrescriptions })),
+  }));
+
+  jest.doMock('../../src/core/v2/doctorContext.service', () => ({
+    DoctorContextService: jest.fn().mockImplementation(() => ({})),
+  }));
+  jest.doMock('../../src/infra/v2/patients.repository', () => ({
+    PatientsRepository: jest.fn().mockImplementation(() => ({})),
+  }));
+  jest.doMock('../../src/infra/v2/allergies.repository', () => ({
+    AllergiesRepository: jest.fn().mockImplementation(() => ({})),
+  }));
+  jest.doMock('../../src/infra/v2/prescriptions.repository', () => ({
+    PrescriptionsRepository: jest.fn().mockImplementation(() => ({})),
+  }));
+  jest.doMock('../../src/infra/v2/doctors.repository', () => ({
+    DoctorsRepository: jest.fn().mockImplementation(() => ({})),
+  }));
+  jest.doMock('../../src/infra/v2/encounters.repository', () => ({
+    EncountersRepository: jest.fn().mockImplementation(() => ({})),
+  }));
+  jest.doMock('../../src/config/audit', () => ({ sink: 'console', piiRedaction: 'none' }));
+  jest.doMock('../../src/core/v2/audit.service', () => ({ AuditService: jest.fn().mockImplementation(() => ({})) }));
+  jest.doMock('../../src/infra/v2/audit.repository', () => ({ AuditRepository: jest.fn().mockImplementation(() => ({})) }));
+  jest.doMock('../../src/infra/v2/audit.console.repository', () => ({
+    AuditConsoleRepository: jest.fn().mockImplementation(() => ({})),
+  }));
+  jest.doMock('../../src/api/v2/audit/audit.helpers', () => ({ buildAuditContext, safeAudit }));
+
+  let controller;
+  jest.isolateModules(() => {
+    controller = require('../../src/api/v2/patients/patients.controller');
+  });
+
+  return {
+    controller,
+    mocks: {
+      search,
+      getById,
+      getSummary,
+      getPrescriptions,
+      buildAuditContext,
+      safeAudit,
+    },
+  };
+};
+
+describe('Unit: api/v2/patients.controller', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('search returns results and audits each patient result', async () => {
+    const searchResult = [{ id: 'pat-1' }, { id: 'pat-2' }];
+    const { controller, mocks } = loadController({ searchResult });
+
+    const req = { user: { sub: 'doc-1' }, query: { name: 'Jane', dob: '1990-01-01', limit: '5' } };
+    const json = jest.fn();
+
+    await controller.search(req, { json }, jest.fn());
+
+    expect(mocks.search).toHaveBeenCalledWith({ doctorUserId: 'doc-1', name: 'Jane', dob: '1990-01-01', limit: '5' });
+    expect(mocks.safeAudit).toHaveBeenCalledTimes(2);
+    expect(mocks.safeAudit).toHaveBeenNthCalledWith(
+      1,
+      expect.any(Object),
+      expect.objectContaining({ eventType: 'patient_search_result', subjectType: 'patient', subjectId: 'pat-1' })
+    );
+    expect(json).toHaveBeenCalledWith({ results: searchResult });
+  });
+
+  it('getPatient returns patient and emits patient_view audit', async () => {
+    const { controller, mocks } = loadController({ patientResult: { id: 'pat-9', firstName: 'Joe' } });
+    const req = { user: { sub: 'doc-1' }, params: { id: 'pat-9' } };
+    const json = jest.fn();
+
+    await controller.getPatient(req, { json }, jest.fn());
+
+    expect(mocks.getById).toHaveBeenCalledWith({ doctorUserId: 'doc-1', patientId: 'pat-9' });
+    expect(mocks.safeAudit).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ eventType: 'patient_view', subjectType: 'patient', subjectId: 'pat-9' })
+    );
+    expect(json).toHaveBeenCalledWith({ id: 'pat-9', firstName: 'Joe' });
+  });
+
+  it('getSummary returns summary and audits counts', async () => {
+    const summaryResult = {
+      patient: { id: 'pat-1' },
+      allergies: [{ id: 'a1' }, { id: 'a2' }],
+      prescriptions: [{ id: 'rx1' }],
+    };
+    const { controller, mocks } = loadController({ summaryResult });
+    const req = { user: { sub: 'doc-2' }, params: { id: 'pat-1' } };
+    const json = jest.fn();
+
+    await controller.getSummary(req, { json }, jest.fn());
+
+    expect(mocks.getSummary).toHaveBeenCalledWith({ doctorUserId: 'doc-2', patientId: 'pat-1' });
+    expect(mocks.safeAudit).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        eventType: 'patient_summary_view',
+        subjectId: 'pat-1',
+        metadata: expect.objectContaining({ allergiesCount: 2, prescriptionsCount: 1 }),
+      })
+    );
+    expect(json).toHaveBeenCalledWith(summaryResult);
+  });
+
+  it('getPrescriptions returns prescriptions list and audits count', async () => {
+    const prescriptionsResult = [{ id: 'rx1' }, { id: 'rx2' }, { id: 'rx3' }];
+    const { controller, mocks } = loadController({ prescriptionsResult });
+    const req = { user: { sub: 'doc-3' }, params: { id: 'pat-3' } };
+    const json = jest.fn();
+
+    await controller.getPrescriptions(req, { json }, jest.fn());
+
+    expect(mocks.getPrescriptions).toHaveBeenCalledWith({ doctorUserId: 'doc-3', patientId: 'pat-3' });
+    expect(mocks.safeAudit).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        eventType: 'patient_prescriptions_view',
+        subjectId: 'pat-3',
+        metadata: expect.objectContaining({ count: 3 }),
+      })
+    );
+    expect(json).toHaveBeenCalledWith({ prescriptions: prescriptionsResult });
+  });
+
+  it('forwards service errors to next', async () => {
+    const error = new Error('boom');
+    const { controller } = loadController({ searchError: error });
+    const next = jest.fn();
+
+    await controller.search({ user: { sub: 'doc-1' }, query: {} }, { json: jest.fn() }, next);
+
+    expect(next).toHaveBeenCalledWith(error);
+  });
+});

--- a/k8s/base/backend.yaml
+++ b/k8s/base/backend.yaml
@@ -39,7 +39,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: backend
-          image: docker.io/agslima/app-stayheathy-backend:latest 
+          image: docker.io/agslima/app-stayheathy-backend@sha256:0a99302f729b15adbd7e4e53a262eeab35e4b487bfb9e0b2bcfbf66f6ff60326 
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/k8s/base/frontend.yaml
+++ b/k8s/base/frontend.yaml
@@ -39,7 +39,7 @@ spec:
 
       containers:
         - name: frontend
-          image: docker.io/agslima/app-stayheathy-frontend:latest 
+          image: docker.io/agslima/app-stayheathy-frontend@sha256:adc8d33f2764db79b74b863f620ad677da28b21eca9c669d79dcee3f4627bae0 
           imagePullPolicy: Always     
           ports:
             - containerPort: 8080

--- a/scripts/trivy-report.sh
+++ b/scripts/trivy-report.sh
@@ -17,7 +17,9 @@ TRIVY_VERSION="${TRIVY_VERSION:-v0.69.3}"
 
 if ! command -v trivy >/dev/null 2>&1; then
   echo "Installing Trivy ${TRIVY_VERSION}..."
-  curl -sfL "https://raw.githubusercontent.com/aquasecurity/trivy/${TRIVY_VERSION}/contrib/install.sh" \
+  curl --fail --silent --show-error --location \
+    --proto "=https" --proto-redir "=https" \
+    "https://raw.githubusercontent.com/aquasecurity/trivy/${TRIVY_VERSION}/contrib/install.sh" \
     | sh -s -- -b /tmp/trivy-bin "${TRIVY_VERSION}"
   export PATH="/tmp/trivy-bin:$PATH"
 fi


### PR DESCRIPTION
### Motivation
- Ensure the API only runs over HTTPS and tighten OIDC authentication/mfa handling to avoid accidental insecure deployment.  
- Improve reliability and safety of maintenance/dev tooling and CI by hardening scripts, adding timeouts, and passing secrets/vars into workflow steps.  
- Improve test coverage for the v2 API surface and client auth flows.  
- Make the client container generate TLS certs at startup and pin deployed images for reproducible k8s deployments.

### Description
- Server: require `TLS_CERT_PATH`/`TLS_KEY_PATH` and always start an `https` server, logging and exiting if missing, and refactor auth middleware to attempt OIDC verification when `oidcConfig.enabled`, return `OIDC_REQUIRED` when appropriate, and only surface other OIDC errors selectively.  
- Auth/jwt: removed the `decode` helper from `jwtToken.service.js` and adjusted verification flow to prefer OIDC verification when enabled.  
- DB migration: extracted legacy prescriptions migration into `migrateLegacyPrescriptions` and invoke it from the main migration, preserving the legacy->v2 data transformation.  
- Frontend: replaced the hardcoded session key with an env-driven `import.meta.env.VITE_PATIENT_PORTAL_SESSION_STORAGE_KEY` fallback and updated session storage uses.  
- Tests: added client tests (`app/client/src/api/patientPortalApi.test.js`) using `vitest` and many new server unit tests under `app/server/tests/unit/*` (controllers, services, repositories, schemas, and audit helpers) using Jest.  
- Docker/frontend: added `docker/generate-client-cert.sh` and copy it into the client image via `Dockerfile.client` so ephemeral certs are generated at container start.  
- Scripts: hardened many shell scripts to use `[[ ... ]]` conditionals, improved error handling, added curl timeouts (`--connect-timeout`/`--max-time`) in CI DAST workflow calls, and improved Trivy install curl flags.  
- CI & infra: pass more `vars`/`secrets` into the DAST workflow step environment, use step-level env vars for compose secrets, and pin k8s frontend/backend images to specific digests in `k8s/base/*` for reproducible deployments.

### Testing
- Ran the server unit test suite with `npm test` (Jest) for added unit tests under `app/server/tests/unit/` and they passed.  
- Ran the client unit tests with `vitest` for `app/client/src/api/patientPortalApi.test.js` and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af62bf3068832da4be6e707d567e6a)