### PR TITLE
docs: Add governance-drift check, tighten GitOps promotion guardrails, and update governance docs

### DIFF
--- a/.github/workflows/ci-pr-validation.yml
+++ b/.github/workflows/ci-pr-validation.yml
@@ -121,7 +121,7 @@ jobs:
           fetch-depth: 0
 
       - name: Governance Drift Check (docs/workflow refs)
-        run: ./scripts/check-governance-drift.sh
+        run: make governance-drift-check
 
       # 1. Secret Scanning
       - name: Secret Scanning (Gitleaks)

--- a/.github/workflows/ci-pr-validation.yml
+++ b/.github/workflows/ci-pr-validation.yml
@@ -120,6 +120,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Governance Drift Check (docs/workflow refs)
+        run: ./scripts/check-governance-drift.sh
+
       # 1. Secret Scanning
       - name: Secret Scanning (Gitleaks)
         uses: gitleaks/gitleaks-action@v2

--- a/.github/workflows/gitops-enforce.yml
+++ b/.github/workflows/gitops-enforce.yml
@@ -22,53 +22,57 @@ env:
   YQ_VERSION: "v4.44.3"
   
 jobs:
-  # verify-context:
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: read
-  #   outputs:
-  #     release_tag: ${{ steps.validate.outputs.release_tag }}
-  #   steps:
-  #     - name: Guardrails - Validate Source
-  #       id: validate
-  #       env:
-  #         TRIGGER_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
-  #         CURRENT_REPO: ${{ github.repository }}
-  #         TRIGGER_EVENT: ${{ github.event.workflow_run.event }}
-  #         HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-  #         REF_NAME: ${{ github.event.workflow_run.head_branch }} # Or extract tag from ref
-  #       run: |
-  #         set -euo pipefail
+  verify-context:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      release_run_id: ${{ steps.validate.outputs.release_run_id }}
+    steps:
+      - name: Guardrails - Validate promotion source
+        id: validate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CURRENT_REPO: ${{ github.repository }}
+          INPUT_RUN_ID: ${{ inputs.run_id }}
+          WR_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          WR_HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          WR_EVENT: ${{ github.event.workflow_run.event }}
+          WR_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
 
-  #         # 1. Security Check: Block Forks
-  #         if [ "$TRIGGER_REPO" != "$CURRENT_REPO" ]; then
-  #           echo "::error::Security: Workflow run originated from a fork ($TRIGGER_REPO). Aborting."
-  #           exit 1
-  #         fi
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            test -n "$INPUT_RUN_ID" || (echo "::error::workflow_dispatch requires run_id input."; exit 1)
+            echo "release_run_id=$INPUT_RUN_ID" >> "$GITHUB_OUTPUT"
+            echo "✅ Manual promotion request validated (run_id provided)."
+            exit 0
+          fi
 
-  #         # 2. Logic Check: Only allow main or tags
-  #         if [ "$TRIGGER_EVENT" == "workflow_dispatch" ] && [ "$HEAD_BRANCH" != "main" ]; then
-  #            echo "::error::Manual releases must be triggered from main."
-  #            exit 1
-  #         fi
+          test -n "$WR_RUN_ID" || (echo "::error::Missing workflow_run.id for workflow_run trigger."; exit 1)
 
-  #         echo "Validation Passed."
-          
-  #         # Pass the tag/ref to the next job safely
-  #         echo "release_tag=$REF_NAME" >> "$GITHUB_OUTPUT"
+          if [[ "$WR_CONCLUSION" != "success" ]]; then
+            echo "::error::Upstream Release workflow did not succeed (conclusion=$WR_CONCLUSION)."
+            exit 1
+          fi
 
-  # JOB 2: The Protected Deployment
-  # Only runs if 'verify-context' succeeds.
+          if [[ "$WR_HEAD_REPO" != "$CURRENT_REPO" ]]; then
+            echo "::error::Security: workflow_run originated from a different repository ($WR_HEAD_REPO)."
+            exit 1
+          fi
+
+          if [[ "$WR_EVENT" != "push" && "$WR_EVENT" != "workflow_dispatch" ]]; then
+            echo "::error::Unsupported Release trigger event ($WR_EVENT). Expected push or workflow_dispatch."
+            exit 1
+          fi
+
+          echo "release_run_id=$WR_RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "✅ workflow_run promotion source validated."
+
   gitops:
     runs-on: ubuntu-latest
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' &&
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_repository.full_name == github.repository)
-    # needs: verify-context
-    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    # environment: production
+    needs: [verify-context]
+    if: ${{ needs.verify-context.result == 'success' }}
     permissions:
       contents: write
       pull-requests: write
@@ -84,7 +88,7 @@ jobs:
         id: release-meta
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUN_ID: ${{ inputs.run_id || github.event.workflow_run.id }}
+          RUN_ID: ${{ needs.verify-context.outputs.release_run_id }}
         run: |
           set -euo pipefail
           test -n "$RUN_ID" || (echo "::error::Missing release run id."; exit 1)

--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,5 @@ snyk-report:
 # Governance Drift Check (docs/workflow refs)
 .PHONY: governance-drift-check
 governance-drift-check:
-    ./scripts/check-governance-drift.sh
+	./scripts/check-governance-drift.sh
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,16 @@
 
-.PHONY: trivy-report
+# Tryvi local scan
+.PHONY: trivy-scan
 trivy-report:
 	./scripts/trivy-report.sh
 
+# Snyk weekly report scan
 .PHONY: snyk-report
 snyk-report:
 	./scripts/run-snyk-aggregate.sh
+
+# Governance Drift Check (docs/workflow refs)
+.PHONY: governance-drift-check
+governance-drift-check:
+    ./scripts/check-governance-drift.sh
+

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -31,7 +31,7 @@ This matrix links README governance claims to exact implementation points so cla
 | Governance cannot be bypassed via direct merge/promotion | `.github/workflows/ci-pr-validation.yml`, `.github/workflows/gitops-enforce.yml` (`verify-context`) | GitHub branch/tag protections + CODEOWNERS + Kyverno break-glass controls | `docs/governance.md`, `docs/adr/005-break-glass-exception-handling.md` |
 | Vulnerability policy threshold is enforced (`HIGH > 5` blocks release) | `.github/workflows/ci-release-gate.yml` (`Gate (CRITICAL>0 or HIGH>5)`) | Trivy attestation + admission policy verification path | `readme.md`, `docs/governance.md`, `docs/adr/004-vulnerability-thresholds-risk-acceptance.md` |
 
-## Required GitHub Settings
+## GitHub Settings
 
 To keep the governance claims in this document auditable and enforceable, the following repository settings must remain enabled in GitHub:
 
@@ -59,7 +59,43 @@ To keep the governance claims in this document auditable and enforceable, the fo
 - ✅ Tag creation is restricted to trusted maintainers / release managers
 - ✅ Release pipeline is triggered from protected tags, not manual artifact uploads
 
-> If any of these controls are disabled, governance guarantees become advisory rather than enforced, increasing audit risk and configuration drift.
+### Controls-to-Workflow Mapping
+
+Use this table during reviews to ensure governance controls remain mapped to active workflows (and to detect drift when workflow names/jobs change).
+
+| Governance Control | Workflow / Job Source | Enforcement Signal |
+| :--- | :--- | :--- |
+| PR lint/test quality gate | `.github/workflows/ci-pr-validation.yml` → `code-quality` | Required PR status check passes before merge |
+| Dockerfile/manifests/policy hygiene | `.github/workflows/ci-pr-validation.yml` → `infra-lint` (Hadolint, Conftest, Kubeconform, Kyverno tests) | Required PR status check passes before merge |
+| Secret + vulnerability + misconfiguration PR gate | `.github/workflows/ci-pr-validation.yml` → `security-scan` (Gitleaks + Trivy FS/config) | Required PR status check passes before merge |
+| Scheduled deep security evidence | `.github/workflows/ci-security-deep.yml` → `security-governance` (Gitleaks + Trivy SARIF/JSON + risk-acceptance gate) | Artifacts/SARIF generated; issue raised on failure |
+| Release vulnerability gate by immutable digest | `.github/workflows/ci-release-gate.yml` → `trivy-scan` | Release blocks on policy thresholds (`CRITICAL>0` or `HIGH>5`) |
+| Release DAST gate | `.github/workflows/ci-release-gate.yml` → `dast-analysis` (OWASP ZAP baseline scans) | Release blocks on DAST gate criteria |
+| Artifact signing, SBOM, and provenance attestations | `.github/workflows/ci-release-gate.yml` signing/attestation jobs | Attestations bound to trusted workflow identity |
+
+## SLSA Level Review and Requirement Mapping
+
+Current documented posture is **SLSA Build L2 with L3-aligned controls in progress** (not a formal certification claim). 
+
+### Why this level statement is defensible
+
+- ✅ Provenance is generated in the trusted release workflow via `actions/attest-build-provenance` and tied to immutable image digests.
+- ✅ Release builds, scanning gates, signing, and attestations run in hosted CI with workflow identity constraints.
+- ✅ Runtime/GitOps verification validates signature and required attestations (including SLSA predicate) before promotion/deployment.
+- ⚠️ Some SLSA L3 expectations (for example independently validated hermetic/reproducible builds) are not yet fully evidenced in this project today.
+
+### SLSA Requirement → Control → Evidence Matrix
+
+| SLSA Requirement (Build Track) | Implemented Control | Evidence Source / Workflow Artifact |
+| :--- | :--- | :--- |
+| Provenance is generated for build outputs | `actions/attest-build-provenance` emits provenance for each release image digest | `.github/workflows/ci-release-gate.yml` (`sign-and-attest` job), registry attestation with predicate `https://slsa.dev/provenance/v1` |
+| Provenance is bound to immutable artifact identity | Build/promotion use digest-pinned images; attestations/signatures reference digest subjects | `digest-*` artifacts from release workflow + digest-based image refs in GitOps promotion |
+| Trusted builder identity | OIDC-based keyless identity restricted to release workflow tag refs | Cosign verify identity regex in release verification and Kyverno `verify-slsa` policy subject regex |
+| Build steps are policy-gated before trust is granted | Trivy and ZAP release gates must pass before `sign-and-attest` runs | `.github/workflows/ci-release-gate.yml` (`trivy-scan`, `dast-analysis`, `sign-and-attest`) |
+| Non-falsifiable evidence retained for audit | Trivy/ZAP outputs, SBOMs, digests, Kyverno logs uploaded as workflow artifacts | Release artifacts (`trivy-results-*`, `zap-results`, `sbom-*`, `digest-*`) and GitOps artifact `kyverno-gitops-log` |
+| Admission/runtime enforces provenance presence | Kyverno policy requires SLSA provenance attestation from trusted issuer/workflow | `k8s/policies/cluster/verify-slsa.yaml` + GitOps `kyverno apply` output/log |
+
+> Governance note: treat this table as the requirement-by-requirement source of truth. Update it whenever workflow jobs, predicate types, or admission policies change.
 
 ### Quarterly Verification Checklist (Maintainer Audit)
 
@@ -78,44 +114,6 @@ Run this checklist at least once per quarter and record completion in your gover
 - [ ] Confirm protected release tag pattern `v*.*.*` exists and still restricts who can create release tags.
 - [ ] Confirm production deployment environment still restricts deployments to release tags and required reviewers.
 - [ ] Confirm any exceptions (break-glass or temporary override) were documented, approved, and time-bounded.
-
-### Controls-to-Workflow Mapping
-
-Use this table during reviews to ensure governance controls remain mapped to active workflows (and to detect drift when workflow names/jobs change).
-
-| Governance Control | Workflow / Job Source | Enforcement Signal |
-| :--- | :--- | :--- |
-| PR lint/test quality gate | `.github/workflows/ci-pr-validation.yml` → `code-quality` | Required PR status check passes before merge |
-| Dockerfile/manifests/policy hygiene | `.github/workflows/ci-pr-validation.yml` → `infra-lint` (Hadolint, Conftest, Kubeconform, Kyverno tests) | Required PR status check passes before merge |
-| Secret + vulnerability + misconfiguration PR gate | `.github/workflows/ci-pr-validation.yml` → `security-scan` (Gitleaks + Trivy FS/config) | Required PR status check passes before merge |
-| Scheduled deep security evidence | `.github/workflows/ci-security-deep.yml` → `security-governance` (Gitleaks + Trivy SARIF/JSON + risk-acceptance gate) | Artifacts/SARIF generated; issue raised on failure |
-| Release vulnerability gate by immutable digest | `.github/workflows/ci-release-gate.yml` → `trivy-scan` | Release blocks on policy thresholds (`CRITICAL>0` or `HIGH>5`) |
-| Release DAST gate | `.github/workflows/ci-release-gate.yml` → `dast-analysis` (OWASP ZAP baseline scans) | Release blocks on DAST gate criteria |
-| Artifact signing, SBOM, and provenance attestations | `.github/workflows/ci-release-gate.yml` signing/attestation jobs | Attestations bound to trusted workflow identity |
-
-## SLSA Level Review and Requirement Mapping
-
-Current documented posture is **SLSA Build L2 with L3-aligned controls in progress** (not a formal certification claim). This keeps claims defensible to the controls currently implemented in-repo and in GitHub settings.
-
-### Why this level statement is defensible
-
-- ✅ Provenance is generated in the trusted release workflow via `actions/attest-build-provenance` and tied to immutable image digests.
-- ✅ Release builds, scanning gates, signing, and attestations run in hosted CI with workflow identity constraints.
-- ✅ Runtime/GitOps verification validates signature and required attestations (including SLSA predicate) before promotion/deployment.
-- ⚠️ Some SLSA L3 expectations (for example independently validated hermetic/reproducible builds) are not fully evidenced in this repository today.
-
-### SLSA Requirement → Control → Evidence Matrix
-
-| SLSA Requirement (Build Track) | Implemented Control | Evidence Source / Workflow Artifact |
-| :--- | :--- | :--- |
-| Provenance is generated for build outputs | `actions/attest-build-provenance` emits provenance for each release image digest | `.github/workflows/ci-release-gate.yml` (`sign-and-attest` job), registry attestation with predicate `https://slsa.dev/provenance/v1` |
-| Provenance is bound to immutable artifact identity | Build/promotion use digest-pinned images; attestations/signatures reference digest subjects | `digest-*` artifacts from release workflow + digest-based image refs in GitOps promotion |
-| Trusted builder identity | OIDC-based keyless identity restricted to release workflow tag refs | Cosign verify identity regex in release verification and Kyverno `verify-slsa` policy subject regex |
-| Build steps are policy-gated before trust is granted | Trivy and ZAP release gates must pass before `sign-and-attest` runs | `.github/workflows/ci-release-gate.yml` (`trivy-scan`, `dast-analysis`, `sign-and-attest`) |
-| Non-falsifiable evidence retained for audit | Trivy/ZAP outputs, SBOMs, digests, Kyverno logs uploaded as workflow artifacts | Release artifacts (`trivy-results-*`, `zap-results`, `sbom-*`, `digest-*`) and GitOps artifact `kyverno-gitops-log` |
-| Admission/runtime enforces provenance presence | Kyverno policy requires SLSA provenance attestation from trusted issuer/workflow | `k8s/policies/cluster/verify-slsa.yaml` + GitOps `kyverno apply` output/log |
-
-> Governance note: treat this table as the requirement-by-requirement source of truth. Update it whenever workflow jobs, predicate types, or admission policies change.
 
 ## GitHub as the Control Plane
 
@@ -207,8 +205,7 @@ This directly supports the design goal:
 - ✅ Require a pull request before merging
 - ✅ Minimum approvals: 1
 - ✅ Dismiss stale approvals on new commits
-- ⚠️ Require CODEOWNER review
-(Optional, but strongly recommended for governance-sensitive files)
+- ✅ Require CODEOWNER review
 
 **Required Status Checks**
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -6,6 +6,10 @@
 
 This model ensures that no artifact can reach production unless it passes policy-defined quality, security, and provenance requirements, enforced before, during, and after CI execution.
 
+## Governance Metadata
+
+- **Last validated (release cadence):** 2026-03-11
+
 ## Summary
 
 This Branch Protection Model ensures that:
@@ -14,6 +18,104 @@ This Branch Protection Model ensures that:
 - Releases are workflow-controlled
 - Artifacts are provable, auditable, and enforceable
 - Governance failures surface immediately — not after deployment
+
+## README Claims → Controls Matrix
+
+This matrix links README governance claims to exact implementation points so claims remain reviewable and auditable.
+
+| README claim | Workflow enforcement | Policy enforcement | Supporting docs |
+| :--- | :--- | :--- | :--- |
+| CI/CD is the primary control plane | `.github/workflows/ci-pr-validation.yml`, `.github/workflows/ci-release-gate.yml`, `.github/workflows/gitops-enforce.yml` | Branch protection required checks; Kyverno validation in GitOps workflow | `readme.md`, `docs/governance.md` |
+| Security checks produce verifiable attestations | `.github/workflows/ci-release-gate.yml` (`trivy-scan`, `dast-analysis`, `sign-and-attest`) | `k8s/policies/cluster/verify-trivy.yaml`, `verify-zap.yaml`, `verify-sbom.yaml`, `verify-slsa.yaml` | `docs/threat-model.md`, `docs/adr/004-vulnerability-thresholds-risk-acceptance.md` |
+| Images are signed/attested and policy-enforced at runtime | `.github/workflows/ci-release-gate.yml` + `.github/workflows/gitops-enforce.yml` | `k8s/policies/cluster/verify-signature.yaml` and attestation verify policies | `docs/governance.md`, `docs/adr/003-policy-enforcement-strategy.md` |
+| Governance cannot be bypassed via direct merge/promotion | `.github/workflows/ci-pr-validation.yml`, `.github/workflows/gitops-enforce.yml` (`verify-context`) | GitHub branch/tag protections + CODEOWNERS + Kyverno break-glass controls | `docs/governance.md`, `docs/adr/005-break-glass-exception-handling.md` |
+| Vulnerability policy threshold is enforced (`HIGH > 5` blocks release) | `.github/workflows/ci-release-gate.yml` (`Gate (CRITICAL>0 or HIGH>5)`) | Trivy attestation + admission policy verification path | `readme.md`, `docs/governance.md`, `docs/adr/004-vulnerability-thresholds-risk-acceptance.md` |
+
+## Required GitHub Settings
+
+To keep the governance claims in this document auditable and enforceable, the following repository settings must remain enabled in GitHub:
+
+### Branch protections (`main`)
+
+- ✅ Require pull requests before merging (direct pushes disabled)
+- ✅ Require at least one approving review
+- ✅ Dismiss stale pull request approvals when new commits are pushed
+- ✅ Require branch to be up to date before merging
+- ✅ Require status checks to pass before merging
+- ✅ Restrict required checks to governance-critical jobs only
+- ✅ Disable force pushes
+- ✅ Disable branch deletion
+- ✅ Disable bypass permissions for branch protections
+
+### CODEOWNER enforcement
+
+- ✅ A valid `.github/CODEOWNERS` file is present and maintained
+- ✅ `Require review from Code Owners` is enabled in branch protection
+- ✅ Governance-sensitive paths remain mapped to accountable owners
+
+### Tag protections (release integrity)
+
+- ✅ Protected tag pattern is configured for release tags (`v*.*.*`)
+- ✅ Tag creation is restricted to trusted maintainers / release managers
+- ✅ Release pipeline is triggered from protected tags, not manual artifact uploads
+
+> If any of these controls are disabled, governance guarantees become advisory rather than enforced, increasing audit risk and configuration drift.
+
+### Quarterly Verification Checklist (Maintainer Audit)
+
+Run this checklist at least once per quarter and record completion in your governance evidence trail (for example, release notes, audit log, or change ticket):
+
+**Audit owner:** `@<github-handle>`
+**Verification date (UTC):** `YYYY-MM-DD`
+**Evidence link / ticket:** `<url-or-ticket-id>`
+
+- [ ] Confirm `main` still requires pull requests and blocks direct pushes.
+- [ ] Confirm required status checks are still configured and match current governance-critical workflows.
+- [ ] Confirm at least one approval and stale approval dismissal are enforced.
+- [ ] Confirm `Require review from Code Owners` remains enabled.
+- [ ] Confirm `.github/CODEOWNERS` still maps governance-sensitive paths to accountable owners.
+- [ ] Confirm force pushes, deletions, and branch-protection bypass are disabled for `main`.
+- [ ] Confirm protected release tag pattern `v*.*.*` exists and still restricts who can create release tags.
+- [ ] Confirm production deployment environment still restricts deployments to release tags and required reviewers.
+- [ ] Confirm any exceptions (break-glass or temporary override) were documented, approved, and time-bounded.
+
+### Controls-to-Workflow Mapping
+
+Use this table during reviews to ensure governance controls remain mapped to active workflows (and to detect drift when workflow names/jobs change).
+
+| Governance Control | Workflow / Job Source | Enforcement Signal |
+| :--- | :--- | :--- |
+| PR lint/test quality gate | `.github/workflows/ci-pr-validation.yml` → `code-quality` | Required PR status check passes before merge |
+| Dockerfile/manifests/policy hygiene | `.github/workflows/ci-pr-validation.yml` → `infra-lint` (Hadolint, Conftest, Kubeconform, Kyverno tests) | Required PR status check passes before merge |
+| Secret + vulnerability + misconfiguration PR gate | `.github/workflows/ci-pr-validation.yml` → `security-scan` (Gitleaks + Trivy FS/config) | Required PR status check passes before merge |
+| Scheduled deep security evidence | `.github/workflows/ci-security-deep.yml` → `security-governance` (Gitleaks + Trivy SARIF/JSON + risk-acceptance gate) | Artifacts/SARIF generated; issue raised on failure |
+| Release vulnerability gate by immutable digest | `.github/workflows/ci-release-gate.yml` → `trivy-scan` | Release blocks on policy thresholds (`CRITICAL>0` or `HIGH>5`) |
+| Release DAST gate | `.github/workflows/ci-release-gate.yml` → `dast-analysis` (OWASP ZAP baseline scans) | Release blocks on DAST gate criteria |
+| Artifact signing, SBOM, and provenance attestations | `.github/workflows/ci-release-gate.yml` signing/attestation jobs | Attestations bound to trusted workflow identity |
+
+## SLSA Level Review and Requirement Mapping
+
+Current documented posture is **SLSA Build L2 with L3-aligned controls in progress** (not a formal certification claim). This keeps claims defensible to the controls currently implemented in-repo and in GitHub settings.
+
+### Why this level statement is defensible
+
+- ✅ Provenance is generated in the trusted release workflow via `actions/attest-build-provenance` and tied to immutable image digests.
+- ✅ Release builds, scanning gates, signing, and attestations run in hosted CI with workflow identity constraints.
+- ✅ Runtime/GitOps verification validates signature and required attestations (including SLSA predicate) before promotion/deployment.
+- ⚠️ Some SLSA L3 expectations (for example independently validated hermetic/reproducible builds) are not fully evidenced in this repository today.
+
+### SLSA Requirement → Control → Evidence Matrix
+
+| SLSA Requirement (Build Track) | Implemented Control | Evidence Source / Workflow Artifact |
+| :--- | :--- | :--- |
+| Provenance is generated for build outputs | `actions/attest-build-provenance` emits provenance for each release image digest | `.github/workflows/ci-release-gate.yml` (`sign-and-attest` job), registry attestation with predicate `https://slsa.dev/provenance/v1` |
+| Provenance is bound to immutable artifact identity | Build/promotion use digest-pinned images; attestations/signatures reference digest subjects | `digest-*` artifacts from release workflow + digest-based image refs in GitOps promotion |
+| Trusted builder identity | OIDC-based keyless identity restricted to release workflow tag refs | Cosign verify identity regex in release verification and Kyverno `verify-slsa` policy subject regex |
+| Build steps are policy-gated before trust is granted | Trivy and ZAP release gates must pass before `sign-and-attest` runs | `.github/workflows/ci-release-gate.yml` (`trivy-scan`, `dast-analysis`, `sign-and-attest`) |
+| Non-falsifiable evidence retained for audit | Trivy/ZAP outputs, SBOMs, digests, Kyverno logs uploaded as workflow artifacts | Release artifacts (`trivy-results-*`, `zap-results`, `sbom-*`, `digest-*`) and GitOps artifact `kyverno-gitops-log` |
+| Admission/runtime enforces provenance presence | Kyverno policy requires SLSA provenance attestation from trusted issuer/workflow | `k8s/policies/cluster/verify-slsa.yaml` + GitOps `kyverno apply` output/log |
+
+> Governance note: treat this table as the requirement-by-requirement source of truth. Update it whenever workflow jobs, predicate types, or admission policies change.
 
 ## GitHub as the Control Plane
 
@@ -238,7 +340,7 @@ cosign verify "$IMAGE" \
 ### Verify SLSA Provenance
 
 ```bash
-# Verify the attestation (SLSA Level 3)
+# Verify the provenance attestation (SLSA predicate)
 cosign verify-attestation "$IMAGE" \
   --type "https://slsa.dev/provenance/v1" \
   --certificate-identity-regexp "^https://github.com/agslima/software-delivery-pipeline/.github/workflows/ci-release-gate\\.yml@refs/tags/v.*" \

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,7 +1,7 @@
 # Operational Runbook 📖
 
 This runbook documents common failure scenarios, security gate rejections, and operational incidents in the Governed Software Delivery Pipeline.
-Its goal is to provide clear, repeatable response steps so failures are handled consistently, audibly, and without bypassing governance controls.
+Its goal is to provide clear, repeatable response steps so failures are handled consistently, auditably, and without bypassing governance controls.
 
 
 ---

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,5 +1,9 @@
 # Security Controls
 
+## Governance Metadata
+
+- **Last validated (release cadence):** 2026-03-11
+
 ## 1. Summary
 
 This document outlines the threat landscape for the **Governed Software Delivery Pipeline**.
@@ -8,7 +12,7 @@ It focuses on software supply-chain risks and the controls implemented in this r
 The security model follows a zero-trust posture for delivery:
 
 - We do not trust source changes by default (PR checks + review gates).
-- We do not trust dependencies by default (Trivy scanning + gated thresholds).
+- We do not trust code, dependencies, or infrastructure config by default (Gitleaks + Trivy scanning with workflow gates).
 - We do not trust artifacts by default (keyless signatures + attestations).
 - We do not trust runtime admission by default (Kyverno verification).
 
@@ -30,8 +34,8 @@ The security model follows a zero-trust posture for delivery:
 
 | Threat Scenario | Attack Vector | Mitigation Control | Implementation Details |
 | :--- | :--- | :--- | :--- |
-| Dependency poisoning / vulnerable transitive packages | Malicious package or critical CVE in dependencies/base image | Trivy vulnerability scanning with release gating | Trivy scans run in PR/deep scans and release gate; release blocks on `CRITICAL > 0` or `HIGH > 5` per image. |
-| Code-level security defects | Vulnerable logic introduced by code change | PR quality gates and runtime security testing | Lint/tests run on PRs; authenticated weekly ZAP and release-gate ZAP provide dynamic validation. |
+| Dependency poisoning / vulnerable transitive packages | Malicious package or critical CVE in dependencies/base image | Trivy image/filesystem scanning with release gating | Trivy runs in PR checks (`fs` vuln + config), daily deep scan (`vuln,secret,config` outputs), and release image gate by digest; release blocks on `CRITICAL > 0` or `HIGH > 5` per image. |
+| Code-level security defects | Vulnerable logic introduced by code change | PR quality gates and DAST in release/weekly workflows | Lint/tests run on PRs; OWASP ZAP baseline scans run in release gate and weekly DAST workflows for dynamic validation. |
 | Artifact mutation in registry | Malicious image pushed to mutable tag | Immutable digests + signing + attestation checks | Deployment uses digest-pinned images; Cosign keyless signatures and attestations are verified before promotion/admission. |
 | Dockerfile/manifest hardening regressions | Insecure Dockerfile or weak manifest config | Hadolint + Conftest + Kubeconform | PR validation blocks non-compliant Dockerfiles/manifests before merge. |
 
@@ -47,7 +51,7 @@ The security model follows a zero-trust posture for delivery:
 
 | Threat Scenario | Attack Vector | Mitigation Control | Implementation Details |
 | :--- | :--- | :--- | :--- |
-| Hardcoded secrets in code/history | Token/credential committed to repository | Gitleaks + Trivy secret scanning | Gitleaks runs in CI; Trivy scans source and config surfaces in scheduled security workflows. |
+| Hardcoded secrets in code/history | Token/credential committed to repository | Gitleaks + Trivy secret/config scanning | Gitleaks runs in PR and daily security workflows; Trivy scans filesystem, dependencies, secrets, and infrastructure config in PR/daily workflows. |
 | Runtime information leakage | Missing headers / endpoint misconfig | OWASP ZAP DAST | Release and weekly DAST scans detect exposed attack surface and missing protections. |
 
 ---
@@ -78,7 +82,7 @@ The security model follows a zero-trust posture for delivery:
 
 ## 5. Residual Risks (Accepted)
 
-- **Zero-day vulnerabilities:** Scanners detect known issues only.
+- **Zero-day vulnerabilities:** Gitleaks/Trivy/ZAP detect known patterns and behaviors only.
   - Mitigation: SBOM and provenance support faster impact triage and incident response.
 - **CI platform compromise:** Trust chain depends on GitHub and OIDC integrity.
   - Mitigation: repository governance controls + admission checks + auditable break-glass process.
@@ -97,9 +101,9 @@ flowchart LR
 
     subgraph CI[Governed CI/CD]
         PR --> Q[Lint + Tests]
-        Q --> S1[Gitleaks + Trivy]
+        Q --> S1[Gitleaks + Trivy FS/Config]
         S1 --> Build[Build + Push by Digest]
-        Build --> DAST[OWASP ZAP]
+        Build --> DAST[OWASP ZAP Baseline]
         DAST --> SA[Sign + Attest + SBOM + Provenance]
     end
 

--- a/readme.md
+++ b/readme.md
@@ -15,8 +15,6 @@
 [![SLSA](https://img.shields.io/badge/SLSA-Level%202-blue?logo=linuxfoundation)](https://github.com/agslima/software-delivery-pipeline/attestations)
 [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
 
-## Governance Metadata
-
 ## TL;DR
 
 This repository demonstrates a **governed software delivery system** in which:

--- a/readme.md
+++ b/readme.md
@@ -112,7 +112,7 @@ graph TD
 
 > This pipeline is intentionally **fail-fast**: artifacts are never built or published unless all required quality gates pass.
 
-For more details on how branch protection, code ownership, and release integrity are enforced, see `docs/governance.md`.
+For more details on how branch protection, code ownership, and release integrity are enforced, see [`docs/governance.md`](docs/governance.md).
 
 ---
 
@@ -127,10 +127,10 @@ For more details on how branch protection, code ownership, and release integrity
 ### Layer 2: Artifact Construction
 
 - **Docker Buildx:** digest-identified builds in the release gate
-- **Hadolint + OPA (Conftest) + Kubeconform:** Dockerfile and Kubernetes manifest validation during PR rev
+- **Hadolint + OPA (Conftest) + Kubeconform:** Dockerfile and Kubernetes manifest validation during PR
 - **OWASP ZAP**: baseline scans in the release path; authenticated scheduled scans for deeper coverage
   
-### Layer 3: Supply Chain Guarantees (SLSA Level 3)
+### Layer 3: Supply Chain Guarantees (SLSA Level 2)
   
 - **Cosign (Keyless):** OIDC-bound image signing
 - **SLSA Provenance:** Verifiable build identity and process
@@ -150,7 +150,7 @@ For more details on how branch protection, code ownership, and release integrity
 - The pipeline utilizes a **Push-based GitOps** model.
 - CI updates Kubernetes manifests with the **immutable image digest** of the newly signed artifact.
 - A Pull Request is automatically opened to `main` with updated digests.
-- **Constraint:** CI cannot commit to main directly; it must pass the same policy checks as a human developer.
+- **Constraint:** CI cannot commit to main directly; it pass the same policy checks as a human developer.
 
 ### Runtime Admission Control
 
@@ -190,7 +190,7 @@ This section summarizes the repository’s current published security posture an
 
 This table is **automatically generated** by the repository security pipeline and reflects the current published vulnerability tracked under [`docs/snyk/`](docs/snyk/index.md).
 
-“Baseline” refers to the intentionally vulnerable starting state used to validate remediation and policy behavior. “Current” reflects the latest published scan snapshot.
+“Baseline / Initial Count” refers to the intentionally vulnerable starting state used to validate remediation and policy behavior. “Current” reflects the latest published scan snapshot.
 
 Interpretation:
 - **Critical / High:** release-blocking until remediated.

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,11 @@
 <!--[![CodeQL](https://github.com/agslima/software-delivery-pipeline/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/agslima/software-delivery-pipeline/actions/workflows/github-code-scanning/codeql)
 [![release](https://img.shields.io/github/v/release/agslima/software-delivery-pipeline?label=Latest%20Verifiable%20Release&color=success)](https://github.com/agslima/software-delivery-pipeline/releases/latest)--> 
 
+## Governance Metadata
+
+- **Last validated (release cadence):** 2026-03-11
+- **Controls matrix:** [`docs/governance.md#readme-claims--controls-matrix`](docs/governance.md#readme-claims--controls-matrix)
+
 ## TL;DR
 
 This repository demonstrates how to design a **governed software delivery system** where:
@@ -25,7 +30,7 @@ This repository demonstrates how to design a **governed software delivery system
 - Governance **cannot be bypassed**, even by developers with write access
 
 > [!NOTE]
-> The application logic is intentionally simple. The value of this repository lies in the **delivery architecture, security controls, and governance model**. For more details about the application, please see the **[`app/README.md`](https://github.com/agslima/software-delivery-pipeline/tree/main/app)**.
+> The application logic is intentionally simple. The value of this repository lies in the **delivery architecture, security controls, and governance model**. For more details about the application, please see the **[`app/readme.md`](https://github.com/agslima/software-delivery-pipeline/blob/main/app/readme.md)**.
 
 ## Project Overview 🛡️
 

--- a/readme.md
+++ b/readme.md
@@ -1,61 +1,52 @@
-# Governed Software Delivery Pipeline (Full-Stack Reference Implementation)
+# Governed Software Delivery Pipeline
 
-## A Production-Grade CI/CD, Supply Chain & Governance Reference
+[//]: # (owner: Project Maintainers)
+[//]: # (review_cadence: Quarterly)
+[//]: # (last_reviewed: 2026-03-11)
+[//]: # (Controls matrix: docs/governance.md#readme-claims--controls-matrix)
+
+## A Reference Implementation for CI/CD Governance, Supply Chain Security, and Runtime Policy Enforcement
 
 [![CI – PR Validation](https://github.com/agslima/software-delivery-pipeline/actions/workflows/ci-pr-validation.yml/badge.svg)](https://github.com/agslima/software-delivery-pipeline/actions/workflows/ci-pr-validation.yml)
 [![CI – Release Gate](https://github.com/agslima/software-delivery-pipeline/actions/workflows/ci-release-gate.yml/badge.svg)](https://github.com/agslima/software-delivery-pipeline/actions/workflows/ci-release-gate.yml)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=agslima_software-delivery-pipeline&metric=security_rating&token=fc36aa04e8597e3ef994141f2c98064a72019cd0)](https://sonarcloud.io/summary/new_code?id=agslima_software-delivery-pipeline)
-[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=agslima_software-delivery-pipeline&metric=reliability_rating&token=fc36aa04e8597e3ef994141f2c98064a72019cd0)](https://sonarcloud.io/summary/new_code?id=agslima_software-delivery-pipeline)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=agslima_software-delivery-pipeline&metric=coverage&token=fc36aa04e8597e3ef994141f2c98064a72019cd0)](https://sonarcloud.io/summary/new_code?id=agslima_software-delivery-pipeline)
-[![SLSA](https://img.shields.io/badge/SLSA-Level%203-blue?logo=linuxfoundation)](https://github.com/agslima/software-delivery-pipeline/attestations)
 [![Infrastructure: Kubernetes](https://img.shields.io/badge/Infra-Kubernetes-326CE5?logo=kubernetes&logoColor=white)](https://github.com/agslima/software-delivery-pipeline/tree/main/k8s)
-[![Security: Trivy](https://img.shields.io/badge/Container-Trivy-0077C2.svg?logo=aquasecurity&logoColor=white)](https://github.com/aquasecurity/trivy)
-[![Security: ZAP](https://img.shields.io/badge/DAST-OWASP%20ZAP-blue?logo=owasp&logoColor=white)](https://www.zaproxy.org/)
+[![SLSA](https://img.shields.io/badge/SLSA-Level%202-blue?logo=linuxfoundation)](https://github.com/agslima/software-delivery-pipeline/attestations)
 [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
-<!--[![CodeQL](https://github.com/agslima/software-delivery-pipeline/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/agslima/software-delivery-pipeline/actions/workflows/github-code-scanning/codeql)
-[![release](https://img.shields.io/github/v/release/agslima/software-delivery-pipeline?label=Latest%20Verifiable%20Release&color=success)](https://github.com/agslima/software-delivery-pipeline/releases/latest)--> 
 
 ## Governance Metadata
 
-- **Last validated (release cadence):** 2026-03-11
-- **Controls matrix:** [`docs/governance.md#readme-claims--controls-matrix`](docs/governance.md#readme-claims--controls-matrix)
-
 ## TL;DR
 
-This repository demonstrates how to design a **governed software delivery system** where:
+This repository demonstrates a **governed software delivery system** in which:
 
-- CI/CD acts as the **primary control plane**
-- Security checks produce **verifiable attestations**, not just logs
-- Container images are **signed, attested, and policy-enforced at runtime**
-- Governance **cannot be bypassed**, even by developers with write access
+- CI/CD is treated as part of the **system’s control plane**
+- Security checks produce **verifiable evidence**, not only workflow logs
+- Container images are **signed, attested, and validated** through policy before deployment
+- The delivery path is designed to make governance bypass **difficult, visible, and auditable**
+
+## Problem Statement 🛡️
+
+While modern projects routinely use tools like Trivy, ZAP, and GitHub Actions, this repository tries to answer a different question: **How do we prevent those controls from being silently bypassed?**
+
+Rather than treating security as a checklist or tooling as the end goal, this repository models **governance as a system property**. It shows how CI/CD, signing, attestations, policy checks, and runtime admission controls can work together to produce **auditable delivery evidence**, not just successful workflow runs.
+
+This is a full-stack reference implementation of a governed delivery pipeline, designed to showcase:
+
+- Governed CI/CD design
+- Software supply-chain integrity controls
+- Risk-based policy enforcement
+- Runtime admission validation tied to build identity
 
 > [!NOTE]
 > The application logic is intentionally simple. The value of this repository lies in the **delivery architecture, security controls, and governance model**. For more details about the application, please see the **[`app/readme.md`](https://github.com/agslima/software-delivery-pipeline/blob/main/app/readme.md)**.
 
-## Project Overview 🛡️
-
-While modern projects routinely use tools like Trivy, ZAP, and GitHub Actions, this repository tries to answer a different question: **How do we prevent those controls from being silently bypassed?**
-
-Instead of focusing on tools alone or treating security as a checkbox, this project serves as a reference implementation for **Governance-as-Code**, demonstrating how to:
-
-- Enforce **security and quality guarantees structurally**
-- Treat CI/CD as **part of the system architecture**
-- Move from “we ran scans” → “**we can prove policy compliance**”
-
-This is a full-stack reference implementation of a governed delivery pipeline, designed to showcase:
-
-- DevOps & Platform Engineering practices
-- Software supply-chain design
-- Risk-based security decision-making
-- Policy-as-Code enforced across CI and runtime
-
-The application exists only to **exercise the pipeline**.
-
 ---
 
-## Engineering Goals
+## Architectural Goals
 
-The architecture was designed to satisfy three core **non-functional requirements**:
+The repository is organized around three core **non-functional goals**:
 
 ### 1. Reliability
 
@@ -65,14 +56,11 @@ The architecture was designed to satisfy three core **non-functional requirement
 
 ### 2. Traceability
 
-Every container image is:
-
-- Built from a specific Git commit
-- Signed using keyless Sigstore (OIDC-bound identity)
-- Attested with:
-  - Build provenance (SLSA Level 3)
-  - SBOM (SPDX)
-  - Vulnerability and DAST results
+Each released container image is tied to a specific Git commit and accompanied by verifiable supply-chain metadata:
+- Keyless Sigstore signature bound to CI identity
+- Build provenance
+- SBOM (SPDX)
+- Attested security evidence from vulnerability and DAST workflows
 
 ### 3. Risk Management (Not Binary Security)
 
@@ -86,16 +74,18 @@ Security is treated as **policy-driven**, not “pass/fail everywhere”:
 
 ## Delivery Architecture (CI/CD as a Control Plane)
 
-GitHub Actions is used intentionally as the **delivery control plane**.
+In this repository, CI/CD is treated as part of the **delivery control plane** rather than as passive automation.
 
 ### Why GitHub Actions?
 
-- Pipeline logic is versioned with the code
-- Branch protection and CODEOWNERS enforce governance before CI runs
-- No external CI trust boundary
+- Pipeline logic is versioned alongside the application and policy code
+- Repository controls such as branch protection and CODEOWNERS are part of the governance model
+- Delivery logic remains repository-native and auditable
 - Clear audit trail from commit → artifact → deployment
 
 ### Pipeline Flow
+
+At a high level, the repository separates governance into three stages: PR validation, release integrity, and delivery enforcement.
 
 ```mermaid
 graph TD
@@ -138,24 +128,21 @@ For more details on how branch protection, code ownership, and release integrity
 
 ### Layer 2: Artifact Construction
 
-- **Docker Buildx** (digest-identified builds in the release gate)
-- **Hadolint + OPA (Conftest) + Kubeconform:** Dockerfile hardening and K8s manifest validation in PRs
-- **OWASP ZAP**
-  - Release gate runs baseline scans against digest-pinned compose
-  - Weekly workflow runs authenticated full scans and uploads SARIF
-  - ZAP results are captured as artifacts; release gate attests results
-
+- **Docker Buildx:** digest-identified builds in the release gate
+- **Hadolint + OPA (Conftest) + Kubeconform:** Dockerfile and Kubernetes manifest validation during PR rev
+- **OWASP ZAP**: baseline scans in the release path; authenticated scheduled scans for deeper coverage
+  
 ### Layer 3: Supply Chain Guarantees (SLSA Level 3)
   
 - **Cosign (Keyless):** OIDC-bound image signing
 - **SLSA Provenance:** Verifiable build identity and process
 - **Syft:** SPDX-formatted SBOM for transparency and future incident response
-- **Typed Attestations:** Cryptographic proof that scans (Trivy/ZAP) actually occurred.
+- **Security attestations:** signed evidence that required scans were executed
 
 ### Layer 4: Delivery (GitOps)
 
-- **Kyverno:** Validates the updated manifests against cluster policies before opening a PR.
-  
+- **Kyverno:** validates deployment manifests against cluster policy expectations before the digest update is proposed for merge
+
 ---
 
 ## Governance & Policy Enforcement
@@ -169,7 +156,7 @@ For more details on how branch protection, code ownership, and release integrity
 
 ### Runtime Admission Control
 
-**Kubernetes** acts as the final gatekeeper using **Kyverno**. The cluster enforces:
+At deployment time, **Kyverno** enforces runtime admission checks inside the cluster.
 
 - ​**Signature Verification:** Is this image signed by our repo?
 - **​Attestation Checks:** Does this image have a SLSA provenance?
@@ -179,14 +166,16 @@ For more details on how branch protection, code ownership, and release integrity
 
 ### Break-Glass (Emergency Access)
 
-- Explicit security.break-glass=true label
-- RBAC-restricted to on-call security role
+- Requires a `security.break-glass=true` label
+- Restricted by RBAC
 - Mandatory justification labels
 - Fully auditable
 
 ---
 
 ## Operational Evidence
+
+This section summarizes the repository’s current published security posture and links to the underlying evidence.
 
 <!-- [BEGIN_GENERATED_TABLE] -->
 ### Automated Security Posture
@@ -201,39 +190,36 @@ For more details on how branch protection, code ownership, and release integrity
 *Last scanned (UTC): 2026-03-09 18:10*
 <!-- [END_GENERATED_TABLE] -->
 
-This table is **automatically generated** by the repository security pipeline and reflects the current **aggregated vulnerability** posture published in [`docs/snyk/`](docs/snyk/index.md).
+This table is **automatically generated** by the repository security pipeline and reflects the current published vulnerability tracked under [`docs/snyk/`](docs/snyk/index.md).
+
+“Baseline” refers to the intentionally vulnerable starting state used to validate remediation and policy behavior. “Current” reflects the latest published scan snapshot.
 
 Interpretation:
 - **Critical / High:** release-blocking until remediated.
 - **Medium / Low:** allowed only when tracked as time-bound managed debt in [`docs/security-debt.md`](docs/security-debt.md).
 - **Managed Debt:** displayed when Medium or Low vulnerabilities remain open under approved governance controls.
 
-### Case Study: Risk Remediation 🔬
+### Case Study 🔬
 
-The application described in [app/readme.md](app/readme.md) was intentionally passed through the pipeline with known security debt to validate vulnerability detection, policy enforcement, and remediation behavior.
+To validate that the governance model works in practice, the application described in [app/readme.md](app/readme.md) was intentionally exercised through the pipeline with known vulnerabilities and security weaknesses. The goal was not to showcase an insecure app, but to demonstrate how the delivery system detects, blocks, tracks, and verifies remediation.
 
 ### Remediation Workflow
 
-- **Baseline:** Initial scans detected 27 Critical vulnerabilities.
+- **Baseline:** initial scans surfaced known dependency and application risks
 - **Triage:** Dependabot automated dependency upgrades; manual changes mitigated issues such as XSS and Prototype Pollution.
-- **Policy Enforcement:** Critical and High findings block delivery. Medium and Low findings may proceed only under documented, time-bound exception governance.
+- **Governance outcome:** Critical and High findings block delivery. Medium and Low findings may proceed only under documented, time-bound exception governance.
 
 ### Evidence
 
-| Initial Vulnerability Scan | Post-Fix Clean Scan |
-| --- | --- |
-| ![Initial Snyk vulnerability scan](https://github.com/agslima/software-delivery-pipeline/blob/main/docs/images/scan-snyk-01.png) | ![Post-remediation Snyk clean scan](https://github.com/agslima/software-delivery-pipeline/blob/main/docs/images/scan-snyk-02.png) |
-
-> [!Note]
-> This section reflects current operational truth for the repository.
-> Managed exceptions are governed in `docs/security-debt.md`.
-> Detailed scan evidence is published in `docs/snyk/` for transparency and auditability.
+| Initial Vulnerability Scan |
+| --- |
+| ![Initial Snyk vulnerability scan](https://github.com/agslima/software-delivery-pipeline/blob/main/docs/images/scan-snyk-01.png) |
 
 ---
 
 ## Verification (How to Audit)
 
-You don't have to trust this documentation. You can cryptographically verify the artifacts yourself.
+You do not need to rely on README claims alone. The release artifacts can be independently verified.
 
 **Prerequisite:** Install [Cosign](https://docs.sigstore.dev/system_config/installation/)
 
@@ -243,7 +229,7 @@ Check that the image was signed by this specific GitHub Repository's CI pipeline
 
 ```bash
 # 1. Export a release image digest (backend or frontend)
-export IMAGE="docker.io/agslima/app-stayheathy-backend@sha256:<digest>"
+export IMAGE="docker.io/agslima/app-stayhealthy-backend@sha256:<digest>"
 
 # 2. Verify the signature against the OpenID Connect (OIDC) identity
 cosign verify "$IMAGE" \
@@ -251,9 +237,10 @@ cosign verify "$IMAGE" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" | jq .
 ```
 
+<!--
 ## Local Development & Testing
 
-### Prerequisites
+### Application Quickstart Prerequisites
 
 - **Node.js 24.13.0** (required by `app/server` and `app/client` `engines.node`)
 - **Docker**
@@ -274,32 +261,36 @@ npm ci
 npm test
 npm run dev
 ```
+### Tooling for Verification
+
+-->
 
 ---
 
-## Technology Stack (Reference)
+## Technology Stack
 
 - **CI/CD:** GitHub Actions
 - **Supply Chain:** Cosign, Syft (SBOM), GitHub build provenance (SLSA)
-- **Security Analysis:** Trivy, OWASP ZAP, Gitleaks
-- **Governance:** Kyverno
-- **Containers:** Docker
-- **Frontend/Backend:** React /Node.js
+- **Security Analysis:** Trivy, Snyk, OWASP ZAP, Gitleaks
+- **Policy enforcement:** Kyverno
+- **Runtime platform:** Docker, Kubernetes 
+- **Application:** React /Node.js
   
 ---
 
 ## What This Repository Demonstrates
 
-- ✅ CI/CD as governance, not automation
-- ✅ Security controls that cannot be silently bypassed
+- ✅ CI/CD treated as governance, not just automation
+- ✅ Security controls designed to be difficult to bypass silently
 - ✅ Policy-driven risk management
 - ✅ Supply-chain guarantees enforced at runtime
-- ✅ Platform-grade GitOps flow
+- ✅ A governed GitOps-style delivery path
 
 ## What This Repository Is Not
 
 - ❌ A framework comparison
 - ❌ A zero-vulnerability application
+- ❌ Not immune to privileged administrative bypass outside the modeled trust boundaries
 
 ---
 

--- a/scripts/check-governance-drift.sh
+++ b/scripts/check-governance-drift.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "::error::$1"
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  grep -Fq "$expected" "$file" || fail "Missing expected reference in $file: $expected"
+}
+
+echo "[governance-drift] Markdown structure assertions"
+assert_contains "readme.md" "# Governed Software Delivery Pipeline (Full-Stack Reference Implementation)"
+assert_contains "docs/governance.md" "# Branch Protection & Governance Model"
+assert_contains "docs/threat-model.md" "# Security Controls"
+
+echo "[governance-drift] Reference assertions: workflow names and policy thresholds"
+assert_contains "readme.md" "HIGH > 5"
+
+assert_contains "docs/governance.md" "## README Claims → Controls Matrix"
+assert_contains "readme.md" "docs/governance.md#readme-claims--controls-matrix"
+assert_contains "docs/governance.md" "ci-release-gate.yml"
+assert_contains "docs/governance.md" "ci-pr-validation.yml"
+assert_contains "docs/governance.md" "gitops-enforce.yml"
+
+assert_contains ".github/workflows/ci-release-gate.yml" "Gate (CRITICAL>0 or HIGH>5)"
+assert_contains ".github/workflows/ci-pr-validation.yml" "name: Security Quality Check"
+assert_contains ".github/workflows/gitops-enforce.yml" "Guardrails - Validate promotion source"
+
+echo "[governance-drift] OK"

--- a/scripts/check-governance-drift.sh
+++ b/scripts/check-governance-drift.sh
@@ -13,7 +13,7 @@ assert_contains() {
 }
 
 echo "[governance-drift] Markdown structure assertions"
-assert_contains "readme.md" "# Governed Software Delivery Pipeline (Full-Stack Reference Implementation)"
+assert_contains "readme.md" "# Governed Software Delivery Pipeline"
 assert_contains "docs/governance.md" "# Branch Protection & Governance Model"
 assert_contains "docs/threat-model.md" "# Security Controls"
 


### PR DESCRIPTION
### Motivation

- Prevent silent drift between documentation, workflow names, and policy thresholds by adding an automated check that asserts canonical references exist in repo files. 
- Make GitOps promotion more robust by validating the `workflow_run`/`workflow_dispatch` source and exposing a canonical `release_run_id` for downstream promotion steps. 
- Improve auditability by surfacing governance metadata and a controls matrix in repository documentation.

### Description

- Add `scripts/check-governance-drift.sh` which performs grep-based assertions against `readme.md`, `docs/governance.md`, `docs/threat-model.md`, and key workflow files to detect documentation/workflow drift. 
- Wire the drift check into the PR security scan by invoking `./scripts/check-governance-drift.sh` in the `security-scan` job of `.github/workflows/ci-pr-validation.yml`. 
- Implement a new `verify-context` job in `.github/workflows/gitops-enforce.yml` that validates promotion source (`workflow_run` or `workflow_dispatch`), emits `release_run_id`, and makes the `gitops` job depend on its success while using the output `RUN_ID` for release metadata resolution. 
- Update documentation files (`docs/governance.md`, `docs/threat-model.md`, `docs/runbook.md`, and `readme.md`) with governance metadata, a README→controls matrix, wording fixes, and verification examples to keep docs aligned with workflow behavior.

### Testing

- No automated tests were executed as part of this PR; the new drift check is wired into the existing CI `security-scan` job and will run on subsequent PRs or workflow executions. 
- The `gitops-enforce` workflow was updated to require and consume `verify-context` outputs, and will be validated by GitHub Actions when promoted runs occur. 
- Shell/runtime assertions in `scripts/check-governance-drift.sh` are fail-closed and will cause the CI `security-scan` job to fail if any expected references are missing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0bd69e4a8832d9bbcec3214b2c7b4)