### PR TITLE
fix: for code scanning alert no. 1398 - Uncontrolled data used in path expression

### DIFF
--- a/scripts/report-governance-slos.py
+++ b/scripts/report-governance-slos.py
@@ -206,7 +206,12 @@ def main() -> None:
         fail("Repository must be provided via --repo in live mode.")
 
     if fixtures_mode:
-        fixtures_dir = pathlib.Path(args.fixtures_dir)
+        fixtures_root = pathlib.Path("fixtures").resolve()
+        fixtures_dir = pathlib.Path(args.fixtures_dir).resolve()
+        try:
+            fixtures_dir.relative_to(fixtures_root)
+        except ValueError:
+            fail(f"Fixtures directory must be within {fixtures_root}: {fixtures_dir}")
         if not fixtures_dir.exists():
             fail(f"Fixtures directory not found: {fixtures_dir}")
         release_runs, release_jobs, pr_runs, pr_jobs, issues_cache = collect_fixture_inputs(fixtures_dir)

--- a/scripts/report-governance-slos.py
+++ b/scripts/report-governance-slos.py
@@ -209,10 +209,7 @@ def main() -> None:
         fixtures_root = pathlib.Path("fixtures").resolve()
         # Ensure the fixtures directory is normalized and confined within fixtures_root
         user_fixtures_arg = pathlib.Path(args.fixtures_dir)
-        if not user_fixtures_arg.is_absolute():
-            candidate_fixtures_dir = (fixtures_root / user_fixtures_arg).resolve()
-        else:
-            candidate_fixtures_dir = user_fixtures_arg.resolve()
+        candidate_fixtures_dir = (fixtures_root / user_fixtures_arg).resolve()
         try:
             candidate_fixtures_dir.relative_to(fixtures_root)
         except ValueError:

--- a/scripts/report-governance-slos.py
+++ b/scripts/report-governance-slos.py
@@ -207,13 +207,19 @@ def main() -> None:
 
     if fixtures_mode:
         fixtures_root = pathlib.Path("fixtures").resolve()
-        fixtures_dir = pathlib.Path(args.fixtures_dir).resolve()
+        # Ensure the fixtures directory is normalized and confined within fixtures_root
+        user_fixtures_arg = pathlib.Path(args.fixtures_dir)
+        if not user_fixtures_arg.is_absolute():
+            candidate_fixtures_dir = (fixtures_root / user_fixtures_arg).resolve()
+        else:
+            candidate_fixtures_dir = user_fixtures_arg.resolve()
         try:
-            fixtures_dir.relative_to(fixtures_root)
+            candidate_fixtures_dir.relative_to(fixtures_root)
         except ValueError:
-            fail(f"Fixtures directory must be within {fixtures_root}: {fixtures_dir}")
-        if not fixtures_dir.exists():
-            fail(f"Fixtures directory not found: {fixtures_dir}")
+            fail(f"Fixtures directory must be within {fixtures_root}: {candidate_fixtures_dir}")
+        if not candidate_fixtures_dir.exists():
+            fail(f"Fixtures directory not found: {candidate_fixtures_dir}")
+        fixtures_dir = candidate_fixtures_dir
         release_runs, release_jobs, pr_runs, pr_jobs, issues_cache = collect_fixture_inputs(fixtures_dir)
         mode = "fixture"
         repository_name = repo or "fixtures/software-delivery-pipeline"


### PR DESCRIPTION
Potential fix for [https://github.com/agslima/software-delivery-pipeline/security/code-scanning/1398](https://github.com/agslima/software-delivery-pipeline/security/code-scanning/1398)

In general, to fix uncontrolled path usage you should normalize the path and ensure it resides under an expected, safe root directory (or otherwise restrict it to an allow list) before using it in filesystem operations. This prevents abuse of `..` segments or absolute paths from escaping the intended directory tree.

For this script, the safest non‑disruptive change is to constrain `--fixtures-dir` to a directory under a known root (for example `fixtures/` in the repository) and reject any user‑supplied path that would escape that root. We can do this by:

- Defining a `fixtures_root = pathlib.Path("fixtures").resolve()` (or similar) in `main`.
- Resolving and normalizing the user‑provided directory: `fixtures_dir = pathlib.Path(args.fixtures_dir).resolve()`.
- Verifying that the resolved `fixtures_dir` is within `fixtures_root` using `is_relative_to` (Python 3.9+) or a prefix check on `relative_to`.
- Failing with a clear error if the check fails, before any filesystem access.
- Keeping the rest of the logic unchanged.

Concretely in `scripts/report-governance-slos.py`, within `main()`’s `if fixtures_mode:` block around lines 208–213, we will replace the direct assignment and existence check:

```py
fixtures_dir = pathlib.Path(args.fixtures_dir)
if not fixtures_dir.exists():
    fail(f"Fixtures directory not found: {fixtures_dir}")
```

with a version that resolves the path, validates that it is under a safe root (e.g. `fixtures/`), and only then checks existence. No new imports are needed since `pathlib` is already imported and `fail` exists.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
