### PR TITLE
fix: code scanning alert no. 1397; uncontrolled data used in path expression

### DIFF
--- a/scripts/report-governance-slos.py
+++ b/scripts/report-governance-slos.py
@@ -193,7 +193,28 @@ def get_issue(repo: str, issue_ref: str, issues_cache: dict[str, Any], fixtures:
 def main() -> None:
     """Generate the governance SLO report and fail on measured breaches."""
     args = parse_args()
-    output_dir = pathlib.Path(args.output_dir)
+
+    # Normalize and constrain the output directory to be within the current working directory.
+    base_dir = pathlib.Path.cwd().resolve()
+    output_dir_raw = pathlib.Path(args.output_dir)
+    if output_dir_raw.is_absolute():
+        output_dir = output_dir_raw.resolve()
+    else:
+        output_dir = (base_dir / output_dir_raw).resolve()
+
+    # Ensure the resolved output directory is contained within the base directory.
+    try:
+        # Python 3.9+: prefer is_relative_to when available.
+        is_relative = getattr(output_dir, "is_relative_to", None)
+        if callable(is_relative):
+            if not output_dir.is_relative_to(base_dir):
+                fail(f"Refusing to write outside of base directory {base_dir}: {output_dir}")
+        else:
+            # Fallback for older Python versions.
+            output_dir.relative_to(base_dir)
+    except ValueError:
+        fail(f"Refusing to write outside of base directory {base_dir}: {output_dir}")
+
     output_dir.mkdir(parents=True, exist_ok=True)
 
     debt_file = pathlib.Path(args.debt_file)


### PR DESCRIPTION
Potential fix for [https://github.com/agslima/software-delivery-pipeline/security/code-scanning/1397](https://github.com/agslima/software-delivery-pipeline/security/code-scanning/1397)

In general, to fix uncontrolled path usage from CLI arguments, normalize the user-supplied path and ensure it resides within an expected base directory (or otherwise constrain it), rejecting paths that escape that root or use disallowed constructs. This avoids directory traversal and unintended overwrites while still allowing reasonable configurability.

For this script, the simplest robust approach without changing intended functionality is:

- Define a fixed “reports root” directory (for example, the repository root or the current working directory plus the default `artifacts/governance-slo-report`).
- Treat `--output-dir` as *relative to* this root.  
- Normalize the resulting path with `resolve()` (or `normpath`) and verify that it is still inside the root (using `is_relative_to` when available, or a `relative_to` try/except fallback).
- If the check fails, abort with `fail(...)`.

Concretely, in `main()` around lines 195–197:

1. Compute a `base_dir` from the current working directory (or another safe anchor).
2. Build `output_dir_raw = pathlib.Path(args.output_dir)`.
3. If `output_dir_raw` is absolute, treat that as suspicious and either reject it or still force it under `base_dir`. To minimize behavior change while fixing traversal, we’ll allow absolute paths but normalize and check that they stay under `base_dir`; if they do not, we abort.
4. Compute `output_dir = (base_dir / output_dir_raw).resolve()` if `output_dir_raw` is relative, else `output_dir = output_dir_raw.resolve()`.
5. Check that `output_dir` is within `base_dir` using `Path.is_relative_to` when available (Python 3.9+), with a `relative_to` fallback for older versions.
6. Only then call `output_dir.mkdir(...)` and use it to construct `summary_path` and other artifacts.

Because we already import `pathlib`, `sys`, etc., no new imports are needed. All modifications are within `scripts/report-governance-slos.py`’s `main()` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
