### PR TITLE
fix: Update lodash patch version for CVE-2026-4800

### DIFF
--- a/app/server/package-lock.json
+++ b/app/server/package-lock.json
@@ -5188,9 +5188,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {

--- a/docs/security-debt.md
+++ b/docs/security-debt.md
@@ -33,3 +33,4 @@
 | --- | --- | --- | --- | --- | --- | --- |
 | CVE-2025-64756 | HIGH | npm:glob (glob@10.4.5) | Patched to 10.5.0 or 11.1.0 | 2026-01-20 | #115 | Found in npm’s bundled deps (/usr/local/lib/node_modules/npm/...) |
 | CVE-2026-23745 | HIGH | npm:tar (tar@6.2.1, tar@7.4.3) | Patched to 7.5.3 | 2026-01-20 | #115 | Multiple occurrences inside npm dependency tree (e.g., npm/node_modules/tar, cacache/node_modules/tar, node-gyp/node_modules/tar) |
+| CVE-2026-4800 | HIGH | lodash vulnerable to Code Injection via `_.template` imports key names | Patched to 4.18.0 | 2026-04-02 | #148 | lodash version 4.17.23, and the fix is to bump it to 4.18.0. |

--- a/docs/security-debt.md
+++ b/docs/security-debt.md
@@ -33,4 +33,5 @@
 | --- | --- | --- | --- | --- | --- | --- |
 | CVE-2025-64756 | HIGH | npm:glob (glob@10.4.5) | Patched to 10.5.0 or 11.1.0 | 2026-01-20 | #115 | Found in npm’s bundled deps (/usr/local/lib/node_modules/npm/...) |
 | CVE-2026-23745 | HIGH | npm:tar (tar@6.2.1, tar@7.4.3) | Patched to 7.5.3 | 2026-01-20 | #115 | Multiple occurrences inside npm dependency tree (e.g., npm/node_modules/tar, cacache/node_modules/tar, node-gyp/node_modules/tar) |
-| CVE-2026-4800 | HIGH | lodash vulnerable to Code Injection via `_.template` imports key names | Patched to 4.18.0 | 2026-04-02 | #148 | lodash version 4.17.23, and the fix is to bump it to 4.18.0. |
+| CVE-2026-4800 | HIGH | lodash vulnerable to Code Injection via `_.template` imports key names | Patched to 4.18.1 | 2026-04-02 | #148 | Updated to 4.18.1 to address Code Injection via `_.template` imports key
+names. |

--- a/docs/security-debt.md
+++ b/docs/security-debt.md
@@ -33,5 +33,3 @@
 | --- | --- | --- | --- | --- | --- | --- |
 | CVE-2025-64756 | HIGH | npm:glob (glob@10.4.5) | Patched to 10.5.0 or 11.1.0 | 2026-01-20 | #115 | Found in npm’s bundled deps (/usr/local/lib/node_modules/npm/...) |
 | CVE-2026-23745 | HIGH | npm:tar (tar@6.2.1, tar@7.4.3) | Patched to 7.5.3 | 2026-01-20 | #115 | Multiple occurrences inside npm dependency tree (e.g., npm/node_modules/tar, cacache/node_modules/tar, node-gyp/node_modules/tar) |
-| CVE-2026-4800 | HIGH | lodash vulnerable to Code Injection via `_.template` imports key names | Patched to 4.18.1 | 2026-04-02 | #148 | Updated to 4.18.1 to address Code Injection via `_.template` imports key
-names. |

--- a/docs/security-debt.md
+++ b/docs/security-debt.md
@@ -33,3 +33,4 @@
 | --- | --- | --- | --- | --- | --- | --- |
 | CVE-2025-64756 | HIGH | npm:glob (glob@10.4.5) | Patched to 10.5.0 or 11.1.0 | 2026-01-20 | #115 | Found in npm’s bundled deps (/usr/local/lib/node_modules/npm/...) |
 | CVE-2026-23745 | HIGH | npm:tar (tar@6.2.1, tar@7.4.3) | Patched to 7.5.3 | 2026-01-20 | #115 | Multiple occurrences inside npm dependency tree (e.g., npm/node_modules/tar, cacache/node_modules/tar, node-gyp/node_modules/tar) |
+| CVE-2026-4800 | HIGH | lodash vulnerable to Code Injection via `_.template` imports key names | Patched to 4.18.1 | 2026-04-02 | `#148` | Updated to 4.18.1 to address Code Injection via `_.template` imports key names. |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a historical security-debt entry documenting resolution of CVE-2026-4800 (HIGH) affecting lodash via template import; recorded as fixed in version 4.18.1 with resolution date 2026-04-02.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->