### PR TITLE
ci: add push trigger for main branch in CI workflow

### DIFF
--- a/.github/workflows/ci-pr-validation.yml
+++ b/.github/workflows/ci-pr-validation.yml
@@ -1,6 +1,8 @@
 name: CI
 on:
   workflow_dispatch: {}
+  push:
+    branches: [ main ]
   pull_request:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to automatically run on direct commits to the main branch in addition to existing pull request and manual trigger events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->