### PR TITLE
fix: Update SLSA generator workflow version to v2.1.0

### DIFF
--- a/.github/actions/sbom-and-attest/action.yml
+++ b/.github/actions/sbom-and-attest/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: true
   sbom-repository:
     description: 'Repository to save SBOM via Cosign'
-    required: true
+    required: false
 
 runs:
   using: 'composite'
@@ -71,10 +71,7 @@ runs:
     
     - name: Cosign SBOM attestation
       shell: bash
-      env:
-        COSIGN_REPOSITORY: ${{ inputs.sbom-repository }}
       run: |
-        echo "Using COSIGN_REPOSITORY=$COSIGN_REPOSITORY"
         cosign attest \
           --yes \
           --predicate "${{ steps.find-sbom.outputs.sbom_file }}" \

--- a/.github/workflows/ci-release-gate.yml
+++ b/.github/workflows/ci-release-gate.yml
@@ -131,7 +131,7 @@ jobs:
       id-token: write   # To sign the provenance.
       packages: write   # To upload assets to release.
       actions: read     # To read the workflow path.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
     with:
       image: ghcr.io/${{ github.repository_owner }}/${{ matrix.container_name }}
       digest: ${{ matrix.digest }}
@@ -158,7 +158,7 @@ jobs:
       id-token: write   # To sign the provenance.
       packages: write   # To upload assets to release.
       actions: read     # To read the workflow path.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
     with:
       image: docker.io/${{ vars.DOCKER_HUB_USERNAME }}/${{ matrix.container_name }}
       digest: ${{ matrix.digest }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made SBOM repository input optional in the attestation workflow
  * Updated SLSA container provenance generator to version 2.1.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->